### PR TITLE
eng language, roles in groups, kicks, bar for playing voice message, etc

### DIFF
--- a/android-ios-app/composeApp/build.gradle.kts
+++ b/android-ios-app/composeApp/build.gradle.kts
@@ -85,7 +85,6 @@ kotlin {
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)
             implementation(libs.native.driver)
-            implementation(libs.multiplatform.settings.keychain)
         }
 
         commonTest.dependencies {

--- a/android-ios-app/composeApp/src/androidMain/kotlin/com/example/memegram/audio/AudioPlatform.android.kt
+++ b/android-ios-app/composeApp/src/androidMain/kotlin/com/example/memegram/audio/AudioPlatform.android.kt
@@ -133,11 +133,10 @@ class AudioPlayerAndroid : AudioPlayer {
     }
 
     override fun stop() {
-        onCompletionCallback?.invoke()
         onCompletionCallback = null
 
-        player?.stop()
-        player?.release()
+        try { player?.stop() } catch (_: Exception) {}
+        try { player?.release() } catch (_: Exception) {}
         player = null
         tempFile?.delete()
         isPausedState = false
@@ -147,8 +146,25 @@ class AudioPlayerAndroid : AudioPlayer {
     override fun isPaused(): Boolean = isPausedState
 
     override fun getProgress(): Float {
-        val p = player ?: return 0f
-        if (p.duration == 0) return 0f
-        return (p.currentPosition.toFloat() / p.duration.toFloat()).coerceIn(0f, 1f)
+        return try {
+            val p = player ?: return 0f
+            if (p.duration == 0) return 0f
+            (p.currentPosition.toFloat() / p.duration.toFloat()).coerceIn(0f, 1f)
+        } catch (_: IllegalStateException) { 0f }
+    }
+
+    override fun getDurationMs(): Long {
+        return try {
+            val p = player ?: return 0L
+            p.duration.toLong()
+        } catch (_: IllegalStateException) { 0L }
+    }
+
+    override fun seekTo(fraction: Float) {
+        try {
+            val p = player ?: return
+            val target = (fraction.coerceIn(0f, 1f) * p.duration).toInt()
+            p.seekTo(target)
+        } catch (_: IllegalStateException) { }
     }
 }

--- a/android-ios-app/composeApp/src/androidMain/kotlin/com/example/memegram/utils/GallerySaver.android.kt
+++ b/android-ios-app/composeApp/src/androidMain/kotlin/com/example/memegram/utils/GallerySaver.android.kt
@@ -1,0 +1,29 @@
+package com.example.memegram.utils
+
+import android.content.ContentValues
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import com.example.memegram.AppContextHolder
+
+actual fun saveImageToGallery(bytes: ByteArray, filename: String): Boolean {
+    return try {
+        val context = AppContextHolder.context
+        val contentValues = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, filename)
+            put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                put(MediaStore.Images.Media.RELATIVE_PATH, Environment.DIRECTORY_PICTURES + "/Memegram")
+            }
+        }
+        val uri = context.contentResolver.insert(
+            MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+            contentValues
+        ) ?: return false
+        context.contentResolver.openOutputStream(uri)?.use { it.write(bytes) }
+        true
+    } catch (e: Exception) {
+        println("MemegramDebug [GallerySaver]: Failed to save image: ${e.message}")
+        false
+    }
+}

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AddDeviceScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AddDeviceScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import org.koin.compose.viewmodel.koinViewModel
+import com.example.memegram.localization.LocalStrings
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -24,6 +25,7 @@ fun AddDeviceScreen(
     onSuccess: () -> Unit,
     vm: AddDeviceViewModel = koinViewModel()
 ) {
+    val s = LocalStrings.current
     val step  by vm.step.collectAsState()
     val error by vm.error.collectAsState()
 
@@ -37,10 +39,10 @@ fun AddDeviceScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Добавить устройство") },
+                title = { Text(s.addDevice) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Назад")
+                        Icon(Icons.Default.ArrowBack, contentDescription = s.back)
                     }
                 }
             )
@@ -57,7 +59,7 @@ fun AddDeviceScreen(
                 AddDeviceStep.SCANNING -> {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Text(
-                            "Отсканируй QR-код\nс основного устройства",
+                            s.scanQrHint,
                             style = MaterialTheme.typography.titleMedium,
                             textAlign = TextAlign.Center
                         )
@@ -79,7 +81,7 @@ fun AddDeviceScreen(
 
                         Spacer(Modifier.height(16.dp))
                         Text(
-                            "Или вставьте код с другого устройства",
+                            s.pasteCodeHint,
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             textAlign = TextAlign.Center
@@ -93,7 +95,7 @@ fun AddDeviceScreen(
                             OutlinedTextField(
                                 value = manualInput,
                                 onValueChange = { manualInput = it },
-                                label = { Text("Код или QR-ссылка") },
+                                label = { Text(s.codeOrQrLink) },
                                 placeholder = { Text("regId/regCode") },
                                 modifier = Modifier.weight(1f),
                                 singleLine = false,
@@ -109,7 +111,7 @@ fun AddDeviceScreen(
                             ) {
                                 Icon(
                                     Icons.Default.ContentPaste,
-                                    contentDescription = "Вставить",
+                                    contentDescription = s.paste,
                                     tint = MaterialTheme.colorScheme.primary
                                 )
                             }
@@ -121,7 +123,7 @@ fun AddDeviceScreen(
                             enabled = manualInput.isNotBlank(),
                             modifier = Modifier.fillMaxWidth()
                         ) {
-                            Text("Подключить")
+                            Text(s.connect)
                         }
                     }
                 }
@@ -132,7 +134,7 @@ fun AddDeviceScreen(
                         verticalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
                         CircularProgressIndicator()
-                        Text("Отправка данных устройства...")
+                        Text(s.sendingDeviceData)
                     }
                 }
 
@@ -143,12 +145,12 @@ fun AddDeviceScreen(
                     ) {
                         CircularProgressIndicator()
                         Text(
-                            "Ожидаем подтверждения\nот основного устройства",
+                            s.awaitingConfirmation,
                             textAlign = TextAlign.Center,
                             style = MaterialTheme.typography.titleMedium
                         )
                         Text(
-                            "Зайди на основном телефоне в\nНастройки → Связанные устройства\nи нажми «Разрешить»",
+                            s.confirmOnMainDevice,
                             textAlign = TextAlign.Center,
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
@@ -167,7 +169,7 @@ fun AddDeviceScreen(
                             tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(64.dp)
                         )
-                        Text("Устройство добавлено!", style = MaterialTheme.typography.titleMedium)
+                        Text(s.deviceAdded, style = MaterialTheme.typography.titleMedium)
                     }
                 }
 
@@ -183,11 +185,11 @@ fun AddDeviceScreen(
                             modifier = Modifier.size(64.dp)
                         )
                         Text(
-                            error ?: "Произошла ошибка",
+                            error ?: s.errorOccurred,
                             textAlign = TextAlign.Center,
                             color = MaterialTheme.colorScheme.error
                         )
-                        Button(onClick = vm::retryScanning) { Text("Попробовать снова") }
+                        Button(onClick = vm::retryScanning) { Text(s.tryAgain) }
                     }
                 }
             }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/App.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/App.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -18,6 +19,10 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.example.memegram.di.appModule
+import com.example.memegram.localization.EnStrings
+import com.example.memegram.localization.LocalStrings
+import com.example.memegram.localization.RuStrings
+import com.example.memegram.localization.S
 import com.ionspin.kotlin.crypto.LibsodiumInitializer
 import kotlinx.serialization.Serializable
 import org.koin.compose.KoinApplication
@@ -55,6 +60,12 @@ fun App() {
         val themeViewModel = koinViewModel<ThemeViewModel>()
         val topBarColor by themeViewModel.topBarColor.collectAsState()
 
+        val languageViewModel = koinViewModel<LanguageViewModel>()
+        val currentLang by languageViewModel.currentLang.collectAsState()
+        val strings = if (currentLang == "ru") RuStrings else EnStrings
+        LaunchedEffect(strings) { S.current = strings }
+
+        CompositionLocalProvider(LocalStrings provides strings) {
         MaterialTheme {
             Surface {
                 val navController = rememberNavController()
@@ -76,7 +87,8 @@ fun App() {
                             onAddDevice = {
                                 navController.navigate(AddDeviceRoute)
                             },
-                            viewModel = viewModel
+                            viewModel = viewModel,
+                            languageViewModel = languageViewModel
                         )
                     }
                     composable<ChatsRoute> {
@@ -95,7 +107,7 @@ fun App() {
                             onNavigateToChat = { convId ->
                                 navController.navigate(
                                     ChatDetailRoute(
-                                        chatName = "Новый чат",
+                                        chatName = strings.newChat,
                                         conversationId = convId
                                     )
                                 )
@@ -273,7 +285,7 @@ fun App() {
                         CreateGroupScreen(
                             onBack = { navController.popBackStack() },
                             onGroupCreated = { chatId ->
-                                navController.navigate(ChatDetailRoute("Группа", chatId)) {
+                                navController.navigate(ChatDetailRoute(strings.groupDefault, chatId)) {
                                     popUpTo(ChatsRoute)
                                 }
                             }
@@ -292,6 +304,11 @@ fun App() {
                             onLeaveSuccess = {
                                 navController.navigate(ChatsRoute) {
                                     popUpTo(ChatsRoute) { inclusive = true }
+                                }
+                            },
+                            onNavigateToChat = { convId, chatName ->
+                                navController.navigate(ChatDetailRoute(chatName, convId)) {
+                                    popUpTo(ChatsRoute)
                                 }
                             },
                             viewModel = viewModel,
@@ -328,5 +345,6 @@ fun App() {
                 }
             }
         }
+        } // CompositionLocalProvider
     }
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AppearanceScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AppearanceScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.example.memegram.localization.LocalStrings
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -29,6 +30,7 @@ fun AppearanceScreen(
     onTopBarColorChanged: () -> Unit,
     viewModel: AppearanceViewModel
 ) {
+    val s = LocalStrings.current
     val chatBgColor by viewModel.chatBgColor.collectAsState()
     val myBubbleColor by viewModel.myBubbleColor.collectAsState()
     val theirBubbleColor by viewModel.theirBubbleColor.collectAsState()
@@ -39,7 +41,7 @@ fun AppearanceScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Appearance") },
+                title = { Text(s.appearanceTitle) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -63,7 +65,7 @@ fun AppearanceScreen(
                 .padding(paddingValues)
         ) {
             Text(
-                text = "Предпросмотр",
+                text = s.preview,
                 modifier = Modifier.padding(16.dp),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold
@@ -85,7 +87,7 @@ fun AppearanceScreen(
                         modifier = Modifier.fillMaxWidth().height(50.dp)
                     ) {
                         Box(contentAlignment = Alignment.CenterStart, modifier = Modifier.padding(horizontal = 16.dp)) {
-                            Text("Чат", color = previewTopBarTextColor, fontWeight = FontWeight.Bold)
+                            Text(s.chatPreview, color = previewTopBarTextColor, fontWeight = FontWeight.Bold)
                         }
                     }
 
@@ -94,7 +96,7 @@ fun AppearanceScreen(
                     val theirTextColor = if (theirBubbleColor.luminance() > 0.5f) Color.Black else Color.White
                     Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp), contentAlignment = Alignment.CenterStart) {
                         Box(modifier = Modifier.clip(RoundedCornerShape(16.dp, 16.dp, 16.dp, 4.dp)).background(theirBubbleColor).padding(12.dp)) {
-                            Text("Привет! Как дела?", color = theirTextColor)
+                            Text(s.previewMessage1, color = theirTextColor)
                         }
                     }
 
@@ -103,7 +105,7 @@ fun AppearanceScreen(
                     val myTextColor = if (myBubbleColor.luminance() > 0.5f) Color.Black else Color.White
                     Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp), contentAlignment = Alignment.CenterEnd) {
                         Box(modifier = Modifier.clip(RoundedCornerShape(16.dp, 16.dp, 4.dp, 16.dp)).background(myBubbleColor).padding(12.dp)) {
-                            Text("Всё супер, тестирую Compose!", color = myTextColor)
+                            Text(s.previewMessage2, color = myTextColor)
                         }
                     }
                 }
@@ -111,13 +113,15 @@ fun AppearanceScreen(
 
             HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
 
-            SettingItem("Цвет верхней панели", topBarColor) { showColorPickerForKey = "topbar" }
-            SettingItem("Цвет фона чата", chatBgColor) { showColorPickerForKey = "chatbg" }
-            SettingItem("Цвет моих сообщений", myBubbleColor) { showColorPickerForKey = "mybubble" }
-            SettingItem("Цвет чужих сообщений", theirBubbleColor) { showColorPickerForKey = "theirbubble" }
+            SettingItem(s.topBarColor, topBarColor) { showColorPickerForKey = "topbar" }
+            SettingItem(s.chatBgColor, chatBgColor) { showColorPickerForKey = "chatbg" }
+            SettingItem(s.myMessageColor, myBubbleColor) { showColorPickerForKey = "mybubble" }
+            SettingItem(s.otherMessageColor, theirBubbleColor) { showColorPickerForKey = "theirbubble" }
 
             if (showColorPickerForKey != null) {
                 ColorPickerDialog(
+                    title = s.chooseColor,
+                    cancelLabel = s.cancel,
                     onColorSelected = { color ->
                         viewModel.updateColor(showColorPickerForKey!!, color)
                         if (showColorPickerForKey == "topbar") {
@@ -154,7 +158,12 @@ fun SettingItem(title: String, currentColor: Color, onClick: () -> Unit) {
 }
 
 @Composable
-fun ColorPickerDialog(onColorSelected: (Color) -> Unit, onDismiss: () -> Unit) {
+fun ColorPickerDialog(
+    title: String,
+    cancelLabel: String,
+    onColorSelected: (Color) -> Unit,
+    onDismiss: () -> Unit
+) {
     val colors = listOf(
         Color(0xFF6075F2), Color(0xFFF5F5F5), Color(0xFFD1C4E9), Color(0xFFFFFFFF),
         Color(0xFFFF5252), Color(0xFFFF4081), Color(0xFFE040FB), Color(0xFF7C4DFF),
@@ -165,7 +174,7 @@ fun ColorPickerDialog(onColorSelected: (Color) -> Unit, onDismiss: () -> Unit) {
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Выберите цвет") },
+        title = { Text(title) },
         text = {
             LazyVerticalGrid(columns = GridCells.Fixed(4), modifier = Modifier.height(250.dp)) {
                 items(colors) { color ->
@@ -182,7 +191,7 @@ fun ColorPickerDialog(onColorSelected: (Color) -> Unit, onDismiss: () -> Unit) {
             }
         },
         confirmButton = {
-            TextButton(onClick = onDismiss) { Text("Отмена") }
+            TextButton(onClick = onDismiss) { Text(cancelLabel) }
         }
     )
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AuthScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AuthScreen.kt
@@ -2,7 +2,9 @@ package com.example.memegram
 
 import androidx.compose.animation.*
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
@@ -10,6 +12,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
@@ -19,13 +22,29 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.memegram.localization.LocalStrings
 
 @Composable
-fun AuthScreen(onLoginSuccess: () -> Unit, viewModel: AuthViewModel, onAddDevice: () -> Unit,) {
+fun AuthScreen(
+    onLoginSuccess: () -> Unit,
+    viewModel: AuthViewModel,
+    onAddDevice: () -> Unit,
+    languageViewModel: LanguageViewModel,
+) {
     val state by viewModel.uiState.collectAsState()
+    val s = LocalStrings.current
+    val currentLang by languageViewModel.currentLang.collectAsState()
     var isLoginMode by remember { mutableStateOf(false) }
     var username by remember { mutableStateOf("") }
     var inviteCode by remember { mutableStateOf("") }
+    var showLangMenu by remember { mutableStateOf(false) }
+
+    data class LangOption(val code: String, val flag: String, val label: String)
+    val languages = listOf(
+        LangOption("en", "\uD83C\uDDFA\uD83C\uDDF8", "English"),
+        LangOption("ru", "\uD83C\uDDF7\uD83C\uDDFA", "Русский"),
+    )
+    val currentFlag = languages.find { it.code == currentLang }?.flag ?: "\uD83C\uDDFA\uD83C\uDDF8"
 
     LaunchedEffect(state) {
         if (state is AuthState.Success) onLoginSuccess()
@@ -40,6 +59,50 @@ fun AuthScreen(onLoginSuccess: () -> Unit, viewModel: AuthViewModel, onAddDevice
                 )
             )
     ) {
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(top = 16.dp, end = 16.dp)
+        ) {
+            Surface(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(CircleShape)
+                    .clickable { showLangMenu = true },
+                shape = CircleShape,
+                color = Color.White,
+                shadowElevation = 4.dp,
+            ) {
+                Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                    Text(text = currentFlag, fontSize = 22.sp)
+                }
+            }
+            DropdownMenu(
+                expanded = showLangMenu,
+                onDismissRequest = { showLangMenu = false }
+            ) {
+                languages.forEach { lang ->
+                    DropdownMenuItem(
+                        text = {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(text = lang.flag, fontSize = 20.sp)
+                                Spacer(Modifier.width(12.dp))
+                                Text(
+                                    text = lang.label,
+                                    fontWeight = if (lang.code == currentLang) FontWeight.Bold else FontWeight.Normal,
+                                    color = if (lang.code == currentLang) Color(0xFF6075F2) else Color.Unspecified
+                                )
+                            }
+                        },
+                        onClick = {
+                            languageViewModel.setLanguage(lang.code)
+                            showLangMenu = false
+                        }
+                    )
+                }
+            }
+        }
+
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -75,14 +138,14 @@ fun AuthScreen(onLoginSuccess: () -> Unit, viewModel: AuthViewModel, onAddDevice
                             AuthTextField(
                                 value = username,
                                 onValueChange = { username = it },
-                                label = "Никнейм",
+                                label = s.nickname,
                                 icon = Icons.Default.Person,
                             )
                             Spacer(modifier = Modifier.height(12.dp))
                             AuthTextField(
                                 value = inviteCode,
                                 onValueChange = { inviteCode = it },
-                                label = "Инвайт-код",
+                                label = s.inviteCode,
                                 icon = Icons.Default.CardGiftcard,
                                 placeholder = "XXXXXXXX",
                             )
@@ -95,7 +158,7 @@ fun AuthScreen(onLoginSuccess: () -> Unit, viewModel: AuthViewModel, onAddDevice
                         exit = fadeOut() + shrinkVertically()
                     ) {
                         Text(
-                            text = "Вход выполнится автоматически\nс помощью ключа на устройстве",
+                            text = s.autoLoginHint,
                             fontSize = 14.sp,
                             color = Color(0xFF888AA0),
                             textAlign = TextAlign.Center,
@@ -160,7 +223,7 @@ fun AuthScreen(onLoginSuccess: () -> Unit, viewModel: AuthViewModel, onAddDevice
                     )
                 } else {
                     Text(
-                        text = if (isLoginMode) "Войти" else "Зарегистрироваться",
+                        text = if (isLoginMode) s.login else s.register,
                         fontSize = 16.sp,
                         fontWeight = FontWeight.SemiBold,
                         color = Color.White
@@ -172,8 +235,8 @@ fun AuthScreen(onLoginSuccess: () -> Unit, viewModel: AuthViewModel, onAddDevice
 
             TextButton(onClick = { isLoginMode = !isLoginMode }) {
                 Text(
-                    text = if (isLoginMode) "Нет аккаунта? Зарегистрироваться"
-                    else "Уже есть аккаунт? Войти",
+                    text = if (isLoginMode) s.noAccountRegister
+                    else s.hasAccountLogin,
                     color = Color(0xFF6075F2),
                     fontSize = 14.sp,
                     textAlign = TextAlign.Center
@@ -189,7 +252,7 @@ fun AuthScreen(onLoginSuccess: () -> Unit, viewModel: AuthViewModel, onAddDevice
                     modifier = Modifier.size(18.dp)
                 )
                 Spacer(Modifier.width(8.dp))
-                Text("Войти с другого устройства")
+                Text(s.loginFromOtherDevice)
             }
         }
     }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/BlackListScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/BlackListScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.memegram.localization.LocalStrings
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -27,6 +28,7 @@ fun BlackListScreen(
     onBack: () -> Unit,
     viewModel: BlackListViewModel
 ) {
+    val s = LocalStrings.current
     val topBarTextColor = if (topBarColor.luminance() > 0.5f) Color.Black else Color.White
     val blockedUsers by viewModel.blockedUsers.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
@@ -37,9 +39,9 @@ fun BlackListScreen(
     error?.let { msg ->
         AlertDialog(
             onDismissRequest = viewModel::clearError,
-            title = { Text("Ошибка") },
+            title = { Text(s.error) },
             text = { Text(msg) },
-            confirmButton = { TextButton(onClick = viewModel::clearError) { Text("OK") } }
+            confirmButton = { TextButton(onClick = viewModel::clearError) { Text(s.ok) } }
         )
     }
 
@@ -49,16 +51,16 @@ fun BlackListScreen(
             ?: "@${userId.take(8)}"
         AlertDialog(
             onDismissRequest = { pendingUnblockId = null },
-            title = { Text("Разблокировать?") },
-            text = { Text("Разблокировать $name?") },
+            title = { Text(s.unblockTitle) },
+            text = { Text(s.unblockMessage(name)) },
             confirmButton = {
                 TextButton(onClick = {
                     viewModel.unblockUser(userId)
                     pendingUnblockId = null
-                }) { Text("Разблокировать") }
+                }) { Text(s.unblockAction) }
             },
             dismissButton = {
-                TextButton(onClick = { pendingUnblockId = null }) { Text("Отмена") }
+                TextButton(onClick = { pendingUnblockId = null }) { Text(s.cancel) }
             }
         )
     }
@@ -66,7 +68,7 @@ fun BlackListScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Чёрный список") },
+                title = { Text(s.blackListTitle) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = topBarTextColor)
@@ -96,14 +98,14 @@ fun BlackListScreen(
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         Text(
-                            text = "Чёрный список пуст",
+                            text = s.blackListEmpty,
                             style = MaterialTheme.typography.bodyLarge,
                             color = Color.Gray,
                             textAlign = TextAlign.Center
                         )
                         Spacer(Modifier.height(6.dp))
                         Text(
-                            text = "Заблокированные пользователи появятся здесь",
+                            text = s.blockedUsersHint,
                             style = MaterialTheme.typography.bodySmall,
                             color = Color.Gray,
                             textAlign = TextAlign.Center,
@@ -119,6 +121,7 @@ fun BlackListScreen(
                                 displayName = entry.profile?.username
                                     ?: (entry.blockedUserId.take(8) + "..."),
                                 accentColor = topBarColor,
+                                unblockLabel = s.unblockAction,
                                 onUnblock = { pendingUnblockId = entry.blockedUserId }
                             )
                             HorizontalDivider(
@@ -137,6 +140,7 @@ fun BlackListScreen(
 private fun BlockedUserItem(
     displayName: String,
     accentColor: Color,
+    unblockLabel: String,
     onUnblock: () -> Unit
 ) {
     Row(
@@ -176,7 +180,7 @@ private fun BlockedUserItem(
                 contentColor = MaterialTheme.colorScheme.error
             )
         ) {
-            Text("Разблокировать", fontSize = 13.sp)
+            Text(unblockLabel, fontSize = 13.sp)
         }
     }
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -26,6 +27,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
+import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
@@ -40,27 +42,37 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.memegram.audio.AudioPlayer
+import com.example.memegram.audio.GlobalAudioPlayer
+import com.example.memegram.audio.VoicePlaybackBar
 import com.example.memegram.data.gallery.AttachItem
 import com.example.memegram.data.gallery.GalleryThumb
 import com.example.memegram.data.gallery.buildGallerySections
 import com.example.memegram.data.gallery.rememberGalleryLoader
+import com.example.memegram.utils.saveImageToGallery
+import com.example.memegram.localization.LocalStrings
 import io.github.vinceglb.filekit.compose.rememberFilePickerLauncher
 import io.github.vinceglb.filekit.core.PickerMode
 import io.github.vinceglb.filekit.core.PickerType
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Instant
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun ChatScreen(
     topBarColor: Color,
@@ -71,11 +83,15 @@ fun ChatScreen(
 ) {
     val messages       by viewModel.messages.collectAsState()
     val inputText      by viewModel.inputText.collectAsState()
+    val s = LocalStrings.current
     val chatBgColor    by viewModel.chatBgColor.collectAsState()
     val myBubbleColor  by viewModel.myBubbleColor.collectAsState()
     val theirBubbleColor by viewModel.theirBubbleColor.collectAsState()
     val mediaCache by viewModel.mediaCache.collectAsState()
     val topBarTextColor = if (topBarColor.luminance() > 0.5f) Color.Black else Color.White
+
+    val globalAudioPlayer = koinInject<GlobalAudioPlayer>()
+    val audioPlaybackState by globalAudioPlayer.state.collectAsState()
 
     val listState = rememberLazyListState()
 
@@ -163,6 +179,15 @@ fun ChatScreen(
     val messageSenders by viewModel.messageSenders.collectAsState()
     val memberProfiles by viewModel.memberProfiles.collectAsState()
 
+    val replyingTo by viewModel.replyingTo.collectAsState()
+    val replyContext by viewModel.replyContext.collectAsState()
+    val clipboardManager = LocalClipboardManager.current
+    val density = LocalDensity.current
+    val coroutineScope = rememberCoroutineScope()
+    var contextMenuMessage by remember { mutableStateOf<Message?>(null) }
+    var contextMenuOffset by remember { mutableStateOf(DpOffset.Zero) }
+    var messageToDelete by remember { mutableStateOf<Message?>(null) }
+
     val recordState     by viewModel.recordState.collectAsState()
     val recordAmps      by viewModel.voiceAmplitudes.collectAsState()
     val recordDuration  by viewModel.voiceDurationMs.collectAsState()
@@ -190,7 +215,7 @@ fun ChatScreen(
                         verticalAlignment         = Alignment.CenterVertically,
                         horizontalArrangement     = Arrangement.SpaceBetween
                     ) {
-                        Text("Галерея", style = MaterialTheme.typography.titleMedium)
+                        Text(s.gallery, style = MaterialTheme.typography.titleMedium)
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                             OutlinedButton(
                                 onClick        = { filePicker.launch(); showAttachSheet = false },
@@ -198,7 +223,7 @@ fun ChatScreen(
                             ) {
                                 Icon(Icons.Default.AttachFile, null, modifier = Modifier.size(16.dp))
                                 Spacer(Modifier.width(4.dp))
-                                Text("Файл", fontSize = 13.sp)
+                                Text(s.file, fontSize = 13.sp)
                             }
                             OutlinedButton(
                                 onClick        = { imagePicker.launch(); showAttachSheet = false },
@@ -206,7 +231,7 @@ fun ChatScreen(
                             ) {
                                 Icon(Icons.Default.PhotoLibrary, null, modifier = Modifier.size(16.dp))
                                 Spacer(Modifier.width(4.dp))
-                                Text("Все", fontSize = 13.sp)
+                                Text(s.all, fontSize = 13.sp)
                             }
                         }
                     }
@@ -229,10 +254,10 @@ fun ChatScreen(
                                 ) {
                                     Icon(Icons.Default.PhotoLibrary, null, modifier = Modifier.size(48.dp), tint = Color.Gray)
                                     Spacer(Modifier.height(8.dp))
-                                    Text("Нет доступа к галерее", color = Color.Gray)
+                                    Text(s.noGalleryAccess, color = Color.Gray)
                                     Spacer(Modifier.height(8.dp))
                                     Button(onClick = { imagePicker.launch(); showAttachSheet = false }) {
-                                        Text("Открыть галерею")
+                                        Text(s.openGallery)
                                     }
                                 }
                             }
@@ -302,7 +327,7 @@ fun ChatScreen(
                         ) {
                             Icon(Icons.AutoMirrored.Filled.Send, null, modifier = Modifier.size(18.dp))
                             Spacer(Modifier.width(8.dp))
-                            Text("Прикрепить ${pendingGallery.size} ${if (pendingGallery.size == 1) "фото" else "фото"}")
+                            Text(s.attachNPhotos(pendingGallery.size))
                         }
                     }
                 }
@@ -313,10 +338,10 @@ fun ChatScreen(
     if (showMuteDialog) {
         AlertDialog(
             onDismissRequest = { showMuteDialog = false },
-            title = { Text("Отключить уведомления") },
+            title = { Text(s.muteNotifications) },
             text = {
                 Column {
-                    listOf("1 час", "8 часов", "24 часа", "Навсегда").forEach { opt ->
+                    listOf(s.mute1Hour, s.mute8Hours, s.mute24Hours, s.muteForever).forEach { opt ->
                         TextButton(
                             onClick = { showMuteDialog = false },
                             modifier = Modifier.fillMaxWidth()
@@ -325,40 +350,40 @@ fun ChatScreen(
                 }
             },
             confirmButton = {},
-            dismissButton = { TextButton(onClick = { showMuteDialog = false }) { Text("Отмена") } }
+            dismissButton = { TextButton(onClick = { showMuteDialog = false }) { Text(s.cancel) } }
         )
     }
     if (showDeleteDialog) {
         AlertDialog(
             onDismissRequest = { showDeleteDialog = false },
-            title = { Text("Удалить чат?") },
-            text  = { Text("Чат будет удалён для всех участников.") },
+            title = { Text(s.deleteChatTitle) },
+            text  = { Text(s.deleteChatMessage) },
             confirmButton = {
                 TextButton(
                     onClick = { showDeleteDialog = false },
                     colors  = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
-                ) { Text("Удалить для всех") }
+                ) { Text(s.deleteForAll) }
             },
-            dismissButton = { TextButton(onClick = { showDeleteDialog = false }) { Text("Отмена") } }
+            dismissButton = { TextButton(onClick = { showDeleteDialog = false }) { Text(s.cancel) } }
         )
     }
     if (showClearDialog) {
         AlertDialog(
             onDismissRequest = { showClearDialog = false },
-            title = { Text("Очистить историю") },
-            text  = { Text("Выберите, для кого очистить историю сообщений.") },
+            title = { Text(s.clearHistory) },
+            text  = { Text(s.clearHistoryMessage) },
             confirmButton = {
                 TextButton(onClick = { viewModel.clearMessages(); showClearDialog = false }) {
-                    Text("Только у меня")
+                    Text(s.onlyForMe)
                 }
             },
             dismissButton = {
                 Row {
-                    TextButton(onClick = { showClearDialog = false }) { Text("Отмена") }
+                    TextButton(onClick = { showClearDialog = false }) { Text(s.cancel) }
                     TextButton(
                         onClick = { viewModel.clearMessages(); showClearDialog = false },
                         colors  = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
-                    ) { Text("У всех") }
+                    ) { Text(s.forAll) }
                 }
             }
         )
@@ -387,6 +412,24 @@ fun ChatScreen(
                 }
             },
             confirmButton = {}
+        )
+    }
+
+    if (messageToDelete != null) {
+        AlertDialog(
+            onDismissRequest = { messageToDelete = null },
+            title = { Text(s.deleteMessageTitle) },
+            text = { Text(s.deleteMessageText) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        messageToDelete?.let { viewModel.deleteMessage(it) }
+                        messageToDelete = null
+                    },
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
+                ) { Text(s.deleteForAll) }
+            },
+            dismissButton = { TextButton(onClick = { messageToDelete = null }) { Text(s.cancel) } }
         )
     }
 
@@ -427,14 +470,14 @@ fun ChatScreen(
                                 Icon(Icons.Default.MoreVert, null, tint = topBarTextColor)
                             }
                             DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
-                                DropdownMenuItem(text = { Text("Поиск") },          leadingIcon = { Icon(Icons.Default.Search, null) },           onClick = { showMenu = false; isSearchMode = true })
-                                DropdownMenuItem(text = { Text("Звонок") },         leadingIcon = { Icon(Icons.Default.Call, null) },              onClick = { showMenu = false })
-                                DropdownMenuItem(text = { Text("Уведомления") },    leadingIcon = { Icon(Icons.Default.NotificationsOff, null) },  onClick = { showMenu = false; showMuteDialog = true })
-                                DropdownMenuItem(text = { Text("Сменить обои") },   leadingIcon = { Icon(Icons.Default.Wallpaper, null) },         onClick = { showMenu = false })
+                                DropdownMenuItem(text = { Text(s.search) },           leadingIcon = { Icon(Icons.Default.Search, null) },           onClick = { showMenu = false; isSearchMode = true })
+                                DropdownMenuItem(text = { Text(s.call) },             leadingIcon = { Icon(Icons.Default.Call, null) },              onClick = { showMenu = false })
+                                DropdownMenuItem(text = { Text(s.notifications) },    leadingIcon = { Icon(Icons.Default.NotificationsOff, null) },  onClick = { showMenu = false; showMuteDialog = true })
+                                DropdownMenuItem(text = { Text(s.changeWallpaper) },  leadingIcon = { Icon(Icons.Default.Wallpaper, null) },         onClick = { showMenu = false })
                                 HorizontalDivider()
-                                DropdownMenuItem(text = { Text("Очистить историю") }, leadingIcon = { Icon(Icons.Default.CleaningServices, null) }, onClick = { showMenu = false; showClearDialog = true })
+                                DropdownMenuItem(text = { Text(s.clearHistory) }, leadingIcon = { Icon(Icons.Default.CleaningServices, null) }, onClick = { showMenu = false; showClearDialog = true })
                                 DropdownMenuItem(
-                                    text = { Text("Удалить чат", color = MaterialTheme.colorScheme.error) },
+                                    text = { Text(s.deleteChat, color = MaterialTheme.colorScheme.error) },
                                     leadingIcon = { Icon(Icons.Default.Delete, null, tint = MaterialTheme.colorScheme.error) },
                                     onClick = { showMenu = false; showDeleteDialog = true }
                                 )
@@ -454,6 +497,49 @@ fun ChatScreen(
                             horizontalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
                             items(attachments) { item -> AttachmentThumbnail(item) { attachments = attachments - item } }
+                        }
+                        HorizontalDivider()
+                    }
+
+                    if (replyingTo != null) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f))
+                                .padding(horizontal = 12.dp, vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                Icons.AutoMirrored.Filled.Reply, null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp)
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    s.reply,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                                Text(
+                                    text = when {
+                                        replyingTo!!.type == "voice" -> s.voiceMessage
+                                        replyingTo!!.type == "image" && replyingTo!!.text.isBlank() -> s.photo
+                                        replyingTo!!.type == "image" -> replyingTo!!.text.take(100)
+                                        else -> replyingTo!!.text.take(100)
+                                    },
+                                    style = MaterialTheme.typography.bodySmall,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                                )
+                            }
+                            IconButton(
+                                onClick = { viewModel.clearReply() },
+                                modifier = Modifier.size(24.dp)
+                            ) {
+                                Icon(Icons.Default.Close, null, modifier = Modifier.size(16.dp))
+                            }
                         }
                         HorizontalDivider()
                     }
@@ -482,7 +568,7 @@ fun ChatScreen(
                                 Spacer(modifier = Modifier.width(16.dp))
 
                                 if (recordState == ChatViewModel.RecordState.HOLDING) {
-                                    Text("< Свайп для отмены", color = Color.Gray, fontSize = 14.sp)
+                                    Text(s.swipeToCancel, color = Color.Gray, fontSize = 14.sp)
                                 } else {
                                     VoiceWaveform(
                                         amplitudes = recordAmps,
@@ -507,7 +593,7 @@ fun ChatScreen(
                             IconButton(onClick = { }) { Icon(Icons.Default.SentimentSatisfied, null, tint = Color.Gray) }
                             OutlinedTextField(
                                 value = inputText, onValueChange = { viewModel.updateInput(it) },
-                                modifier = Modifier.weight(1f), placeholder = { Text("Сообщение...") },
+                                modifier = Modifier.weight(1f), placeholder = { Text(s.messagePlaceholder) },
                                 shape = RoundedCornerShape(24.dp), maxLines = 5
                             )
                             IconButton(onClick = { galleryLoader.requestPermission(); showAttachSheet = true }) {
@@ -603,12 +689,25 @@ fun ChatScreen(
             }
         }
     ) { paddingValues ->
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(chatBgColor)
                 .padding(paddingValues)
         ) {
+            VoicePlaybackBar(
+                state = audioPlaybackState,
+                onTogglePlayPause = { globalAudioPlayer.togglePlayPause() },
+                onSeek = { globalAudioPlayer.seekTo(it) },
+                onClose = { globalAudioPlayer.stop() },
+                accentColor = topBarColor
+            )
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .background(chatBgColor)
+            ) {
             LazyColumn(
                 state          = listState,
                 modifier       = Modifier.fillMaxSize().padding(horizontal = 12.dp),
@@ -619,37 +718,127 @@ fun ChatScreen(
                     if (message.text.isBlank() && message.mediaId == null && message.localPreviewBytes == null) return@items
                     val senderId = messageSenders[message.serverId]
                     val profile = memberProfiles[senderId]
-                    if (isGroupChat && !message.isOutgoing) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth().padding(bottom = 2.dp),
-                            horizontalArrangement = Arrangement.Start,
-                            verticalAlignment = Alignment.Bottom
+                    val replyToServerId = replyContext[message.serverId]
+                    val replyToMessage = replyToServerId?.let { rid -> messages.find { it.serverId == rid } }
+                    val replyToSenderName = replyToMessage?.let { rm ->
+                        val replySenderId = messageSenders[rm.serverId]
+                        replySenderId?.let { memberProfiles[it]?.username }
+                    }
+                    val isDeleted = message.text == s.messageDeletedEmoji
+                        || message.text == s.messageDeleted
+                        || message.text == "🗑 Сообщение удалено"
+                        || message.text == "Сообщение удалено"
+
+                    if (message.type == "system") {
+                        Box(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                            contentAlignment = Alignment.Center
                         ) {
+                            Text(
+                                text = message.text,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier
+                                    .background(
+                                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+                                        RoundedCornerShape(12.dp)
+                                    )
+                                    .padding(horizontal = 12.dp, vertical = 4.dp)
+                            )
+                        }
+                        return@items
+                    }
+
+                    Box {
+                        if (isGroupChat && !message.isOutgoing) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(bottom = 2.dp)
+                                    .pointerInput(message.id) {
+                                        detectTapGestures(
+                                            onLongPress = { offset ->
+                                                if (!isDeleted) {
+                                                    with(density) {
+                                                        contextMenuOffset = DpOffset(
+                                                            x = offset.x.toDp(),
+                                                            y = offset.y.toDp()
+                                                        )
+                                                    }
+                                                    contextMenuMessage = message
+                                                }
+                                            }
+                                        )
+                                    },
+                                horizontalArrangement = Arrangement.Start,
+                                verticalAlignment = Alignment.Bottom
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(36.dp)
+                                        .clip(CircleShape)
+                                        .background(MaterialTheme.colorScheme.primaryContainer),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = profile?.username?.take(1)?.uppercase() ?: "?",
+                                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                        fontWeight = FontWeight.Bold,
+                                        fontSize = 14.sp
+                                    )
+                                }
+
+                                Spacer(modifier = Modifier.width(8.dp))
+
+                                Column(horizontalAlignment = Alignment.Start) {
+                                    Text(
+                                        text = profile?.username ?: s.member,
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.padding(start = 4.dp, bottom = 2.dp)
+                                    )
+
+                                    MessageBubble(
+                                        message          = message,
+                                        myBubbleColor    = myBubbleColor,
+                                        theirBubbleColor = theirBubbleColor,
+                                        searchQuery      = searchQuery,
+                                        isCurrentMatch   = message.id == currentMatchMsgId,
+                                        mediaCache       = mediaCache,
+                                        onLoadMedia      = { id, meta -> viewModel.loadMedia(id, meta) },
+                                        globalAudioPlayer = globalAudioPlayer,
+                                        chatName         = chatName,
+                                        replyToMessage   = replyToMessage,
+                                        replyToSenderName = replyToSenderName,
+                                        onReplyClick     = replyToMessage?.let { replied ->
+                                            {
+                                                val idx = messages.indexOfFirst { it.serverId == replied.serverId }
+                                                if (idx >= 0) coroutineScope.launch { listState.animateScrollToItem(idx) }
+                                            }
+                                        }
+                                    )
+                                }
+                            }
+                        } else {
                             Box(
                                 modifier = Modifier
-                                    .size(36.dp)
-                                    .clip(CircleShape)
-                                    .background(MaterialTheme.colorScheme.primaryContainer),
-                                contentAlignment = Alignment.Center
+                                    .fillMaxWidth()
+                                    .pointerInput(message.id) {
+                                        detectTapGestures(
+                                            onLongPress = { offset ->
+                                                if (!isDeleted) {
+                                                    with(density) {
+                                                        contextMenuOffset = DpOffset(
+                                                            x = offset.x.toDp(),
+                                                            y = offset.y.toDp()
+                                                        )
+                                                    }
+                                                    contextMenuMessage = message
+                                                }
+                                            }
+                                        )
+                                    }
                             ) {
-                                Text(
-                                    text = profile?.username?.take(1)?.uppercase() ?: "?",
-                                    color = MaterialTheme.colorScheme.onPrimaryContainer,
-                                    fontWeight = FontWeight.Bold,
-                                    fontSize = 14.sp
-                                )
-                            }
-
-                            Spacer(modifier = Modifier.width(8.dp))
-
-                            Column(horizontalAlignment = Alignment.Start) {
-                                Text(
-                                    text = profile?.username ?: "Участник",
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier.padding(start = 4.dp, bottom = 2.dp)
-                                )
-
                                 MessageBubble(
                                     message          = message,
                                     myBubbleColor    = myBubbleColor,
@@ -658,24 +847,80 @@ fun ChatScreen(
                                     isCurrentMatch   = message.id == currentMatchMsgId,
                                     mediaCache       = mediaCache,
                                     onLoadMedia      = { id, meta -> viewModel.loadMedia(id, meta) },
-                                    audioPlayer      = viewModel.audioPlayer
+                                    globalAudioPlayer = globalAudioPlayer,
+                                    chatName         = chatName,
+                                    replyToMessage   = replyToMessage,
+                                    replyToSenderName = replyToSenderName,
+                                    onReplyClick     = replyToMessage?.let { replied ->
+                                        {
+                                            val idx = messages.indexOfFirst { it.serverId == replied.serverId }
+                                            if (idx >= 0) coroutineScope.launch { listState.animateScrollToItem(idx) }
+                                        }
+                                    }
                                 )
                             }
                         }
-                    } else {
-                        MessageBubble(
-                            message          = message,
-                            myBubbleColor    = myBubbleColor,
-                            theirBubbleColor = theirBubbleColor,
-                            searchQuery      = searchQuery,
-                            isCurrentMatch   = message.id == currentMatchMsgId,
-                            mediaCache       = mediaCache,
-                            onLoadMedia      = { id, meta -> viewModel.loadMedia(id, meta) },
-                            audioPlayer      = viewModel.audioPlayer
-                        )
+
+                        DropdownMenu(
+                            expanded = contextMenuMessage?.id == message.id,
+                            onDismissRequest = { contextMenuMessage = null },
+                            offset = contextMenuOffset
+                        ) {
+                            val isImageMsg = message.type == "image" || message.localPreviewBytes != null
+                            val hasText = message.text.isNotBlank() && message.type != "voice"
+
+                            if (isImageMsg) {
+                                DropdownMenuItem(
+                                    text = { Text(s.saveToGallery) },
+                                    leadingIcon = { Icon(Icons.Default.Download, null) },
+                                    onClick = {
+                                        val mediaId = message.mediaId
+                                        contextMenuMessage = null
+                                        if (mediaId != null) {
+                                            val bytes = mediaCache[mediaId]
+                                            if (bytes != null) {
+                                                coroutineScope.launch {
+                                                    saveImageToGallery(bytes, "memegram_$mediaId.jpg")
+                                                }
+                                            }
+                                        }
+                                    }
+                                )
+                            }
+
+                            if (hasText) {
+                                DropdownMenuItem(
+                                    text = { Text(s.copyText) },
+                                    leadingIcon = { Icon(Icons.Default.ContentCopy, null) },
+                                    onClick = {
+                                        clipboardManager.setText(AnnotatedString(message.text))
+                                        contextMenuMessage = null
+                                    }
+                                )
+                            }
+
+                            DropdownMenuItem(
+                                text = { Text(s.reply) },
+                                leadingIcon = { Icon(Icons.AutoMirrored.Filled.Reply, null) },
+                                onClick = {
+                                    viewModel.setReplyTo(message)
+                                    contextMenuMessage = null
+                                }
+                            )
+
+                            DropdownMenuItem(
+                                text = { Text(s.deleteForAll, color = MaterialTheme.colorScheme.error) },
+                                leadingIcon = { Icon(Icons.Default.Delete, null, tint = MaterialTheme.colorScheme.error) },
+                                onClick = {
+                                    messageToDelete = message
+                                    contextMenuMessage = null
+                                }
+                            )
+                        }
                     }
                 }
             }
+        }
         }
     }
 }
@@ -801,9 +1046,14 @@ fun MessageBubble(
     isCurrentMatch: Boolean = false,
     mediaCache: Map<String, ByteArray> = emptyMap(),
     onLoadMedia: (String, String?) -> Unit = { _, _ -> },
-    audioPlayer: AudioPlayer? = null
+    globalAudioPlayer: GlobalAudioPlayer? = null,
+    chatName: String = "",
+    replyToMessage: Message? = null,
+    replyToSenderName: String? = null,
+    onReplyClick: (() -> Unit)? = null
 ) {
     val isOut       = message.isOutgoing
+    val s = LocalStrings.current
     val bubbleColor = if (isCurrentMatch) MaterialTheme.colorScheme.tertiary
     else if (isOut) myBubbleColor else theirBubbleColor
     val textColor   = if (bubbleColor.luminance() > 0.5f) Color.Black else Color.White
@@ -851,26 +1101,62 @@ fun MessageBubble(
                 )
         ) {
             Column {
+                if (replyToMessage != null) {
+                    Box(
+                        modifier = Modifier
+                            .padding(
+                                start = if (isImageMsg && !hasText) 8.dp else 0.dp,
+                                end = if (isImageMsg && !hasText) 8.dp else 0.dp,
+                                top = if (isImageMsg && !hasText) 8.dp else 0.dp,
+                                bottom = 4.dp
+                            )
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(textColor.copy(alpha = 0.1f))
+                            .then(
+                                if (onReplyClick != null) Modifier.clickable { onReplyClick() }
+                                else Modifier
+                            )
+                            .padding(horizontal = 8.dp, vertical = 6.dp)
+                    ) {
+                        Column {
+                            Text(
+                                text = if (replyToMessage.isOutgoing) s.you else (replyToSenderName ?: s.interlocutor),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = if (bubbleColor.luminance() > 0.5f)
+                                    MaterialTheme.colorScheme.primary
+                                else MaterialTheme.colorScheme.inversePrimary,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                text = when {
+                                    replyToMessage.type == "voice" -> s.voiceMessage
+                                    replyToMessage.type == "image" && replyToMessage.text.isBlank() -> s.photo
+                                    replyToMessage.type == "image" -> replyToMessage.text.take(50)
+                                    else -> replyToMessage.text.take(100)
+                                },
+                                style = MaterialTheme.typography.bodySmall,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                                color = textColor.copy(alpha = 0.7f)
+                            )
+                        }
+                    }
+                }
+
                 if (message.type == "voice") {
                     val parts = message.text.split("|")
                     val durationMs = parts[0].toLongOrNull() ?: 0L
                     val waveformStr = if (parts.size > 1) parts[1] else ""
                     val parsedAmps = waveformStr.map { it.digitToIntOrNull() ?: 0 }
 
-                    var isPlaying by remember { mutableStateOf(false) }
-                    var isPausedLocal by remember { mutableStateOf(false) }
-                    var currentProgress by remember { mutableFloatStateOf(0f) }
-
-                    LaunchedEffect(isPlaying, isPausedLocal) {
-                        if (isPlaying) {
-                            while (isPlaying) {
-                                delay(50)
-                                currentProgress = audioPlayer?.getProgress() ?: 0f
-                            }
-                        } else if (!isPausedLocal) {
-                            currentProgress = 0f
-                        }
-                    }
+                    val gapState = globalAudioPlayer?.state?.collectAsState()
+                    val gapValue = gapState?.value
+                    val isThisActive = gapValue != null &&
+                        gapValue.mediaId == message.mediaId &&
+                        gapValue.status != GlobalAudioPlayer.PlaybackStatus.IDLE
+                    val isPlaying = isThisActive && gapValue?.status == GlobalAudioPlayer.PlaybackStatus.PLAYING
+                    val isPaused = isThisActive && gapValue?.status == GlobalAudioPlayer.PlaybackStatus.PAUSED
+                    val currentProgress = if (isThisActive) (gapValue?.progress ?: 0f) else 0f
 
                     val totalSeconds = (durationMs / 1000).toInt()
                     val totalText = "${totalSeconds / 60}:${(totalSeconds % 60).toString().padStart(2, '0')}"
@@ -878,7 +1164,7 @@ fun MessageBubble(
                     val currentSeconds = ((durationMs * currentProgress) / 1000).toInt()
                     val currentText = "${currentSeconds / 60}:${(currentSeconds % 60).toString().padStart(2, '0')}"
 
-                    val displayTime = if (currentProgress > 0f && (isPlaying || isPausedLocal)) {
+                    val displayTime = if (currentProgress > 0f && (isPlaying || isPaused)) {
                         "$currentText / $totalText"
                     } else {
                         totalText
@@ -895,21 +1181,20 @@ fun MessageBubble(
                                 .background(textColor.copy(alpha = 0.15f))
                                 .clickable {
                                     if (isPlaying) {
-                                        audioPlayer?.pause()
-                                        isPlaying = false
-                                        isPausedLocal = true
+                                        globalAudioPlayer?.pause()
+                                    } else if (isPaused) {
+                                        globalAudioPlayer?.resume()
                                     } else {
-                                        if (cachedBytes != null) {
-                                            isPlaying = true
-                                            if (isPausedLocal) {
-                                                audioPlayer?.resume()
-                                                isPausedLocal = false
-                                            } else {
-                                                audioPlayer?.play(cachedBytes) {
-                                                    isPlaying = false
-                                                    isPausedLocal = false
-                                                }
-                                            }
+                                        val bytes = cachedBytes
+                                        val mid = message.mediaId
+                                        if (bytes != null && mid != null && globalAudioPlayer != null) {
+                                            globalAudioPlayer.play(
+                                                bytes = bytes,
+                                                mediaId = mid,
+                                                chatName = chatName,
+                                                durationMs = durationMs,
+                                                waveform = parsedAmps
+                                            )
                                         }
                                     }
                                 },

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatViewModel.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatViewModel.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.memegram.audio.AudioRecordResult
-import com.example.memegram.audio.createAudioPlayer
 import com.example.memegram.audio.createAudioRecorder
 import com.example.memegram.data.local.SessionManager
 import com.example.memegram.data.models.*
@@ -17,6 +16,7 @@ import com.example.memegram.data.gallery.guessMimeType
 import com.example.memegram.data.gallery.readUploadBytes
 import com.example.memegram.mls.decryptMediaBytes
 import com.example.memegram.mls.encryptMediaBytes
+import com.example.memegram.localization.S
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.sync.Mutex
@@ -66,7 +66,6 @@ class ChatViewModel(
         private set
 
     val audioRecorder = createAudioRecorder()
-    val audioPlayer = createAudioPlayer()
     private var myUserId: String? = null
     private var myDeviceId: String? = null
     private var typingJob: Job? = null
@@ -85,6 +84,14 @@ class ChatViewModel(
 
     private val _voiceDurationMs = MutableStateFlow(0L)
     val voiceDurationMs: StateFlow<Long> = _voiceDurationMs.asStateFlow()
+
+    /** The message being replied to (Telegram-style reply bar). */
+    private val _replyingTo = MutableStateFlow<Message?>(null)
+    val replyingTo: StateFlow<Message?> = _replyingTo.asStateFlow()
+
+    /** Map messageServerId → replyToServerId, populated from server data. */
+    private val _replyContext = MutableStateFlow<Map<String, String>>(emptyMap())
+    val replyContext: StateFlow<Map<String, String>> = _replyContext.asStateFlow()
 
     private var recordTimerJob: Job? = null
     private var rawAmplitudes = mutableListOf<Int>()
@@ -131,7 +138,7 @@ class ChatViewModel(
 
             val mlsReady = syncMlsPending(conversationId)
             if (!mlsReady) {
-                _error.value = "MLS не готов для этого чата"
+                _error.value = S.current.mlsNotReady
                 return@launch
             }
 
@@ -150,18 +157,22 @@ class ChatViewModel(
             decryptMutex.withLock {
                 val existingLocalMessages = chatRepository.getMessagesOnce(conversationId)
                 val newSenders = mutableMapOf<String, String>()
+                val newReplyCtx = mutableMapOf<String, String>()
 
                 val uiMessages = sortedMessages.map { msg ->
                     val existing = existingLocalMessages.find { it.serverId == msg.id }
                     val isSentByMe = msg.effectiveSenderId == myId
                     newSenders[msg.id] = msg.effectiveSenderId
+                    if (!msg.replyToMessageId.isNullOrBlank()) {
+                        newReplyCtx[msg.id] = msg.replyToMessageId
+                    }
 
                     val text = when {
                         existing != null && !existing.text.startsWith("🔒") && (existing.text.isNotBlank() || existing.type != "text") -> existing.text
                         else -> try {
-                            mlsManager.decrypt(conversationId, msg.mlsCiphertextB64) ?: "🔒 [Зашифровано]"
+                            mlsManager.decrypt(conversationId, msg.mlsCiphertextB64) ?: S.current.encrypted
                         } catch (_: Exception) {
-                            if (isSentByMe) "🔒 [Отправлено с другого устройства]" else "🔒 [Ошибка расшифровки]"
+                            if (isSentByMe) S.current.sentFromOtherDevice else S.current.decryptionError
                         }
                     }
 
@@ -180,12 +191,13 @@ class ChatViewModel(
                 }
 
                 _messageSenders.update { it + newSenders }
+                _replyContext.update { it + newReplyCtx }
                 chatRepository.saveMessages(uiMessages, conversationId)
                 mlsManager.flushState()
             }
         } catch (e: Exception) {
             println("MemegramDebug: Ошибка в loadMessages: ${e.message}")
-            _error.value = "Ошибка загрузки: ${e.message}"
+            _error.value = S.current.loadError(e.message ?: "")
         } finally {
             _isLoading.value = false
         }
@@ -227,6 +239,9 @@ class ChatViewModel(
                 data.senderUserId?.let { senderId ->
                     _messageSenders.update { it + (msgId to senderId) }
                 }
+                if (!data.replyToMessageId.isNullOrBlank()) {
+                    _replyContext.update { it + (msgId to data.replyToMessageId) }
+                }
                 decryptAndSave(
                     convId        = convId,
                     msgId         = msgId,
@@ -252,12 +267,51 @@ class ChatViewModel(
                 val msgId = data.messageId ?: return
                 val existing = _messages.value.find { it.serverId == msgId }
                 if (existing != null) {
-                    chatRepository.saveMessage(existing.copy(text = "🗑 Сообщение удалено"), convId)
+                    chatRepository.saveMessage(existing.copy(text = S.current.messageDeletedEmoji), convId)
                 }
             }
 
             "epoch_changed" -> syncMlsPending(convId)
+
+            "member_left" -> {
+                val userId = data.userId ?: return
+                val profile = _memberProfiles.value[userId]
+                val name = profile?.username ?: S.current.member
+                insertSystemMessage(convId, S.current.leftGroup(name))
+            }
+
+            "member_kicked" -> {
+                val userId = data.userId ?: return
+                val kickedByUserId = data.kickedBy
+                val profile = _memberProfiles.value[userId]
+                var kickerProfile = kickedByUserId?.let { _memberProfiles.value[it] }
+                if (kickerProfile == null && kickedByUserId != null) {
+                    kickerProfile = try {
+                        val fetched = api.getUserById(kickedByUserId)
+                        _memberProfiles.update { it + (kickedByUserId to fetched) }
+                        fetched
+                    } catch (_: Exception) { null }
+                }
+                val kickedName = profile?.username ?: S.current.member
+                val kickerName = kickerProfile?.username ?: S.current.admin
+                insertSystemMessage(convId, S.current.removedFromGroup(kickerName, kickedName))
+            }
         }
+    }
+
+    // ───────────────────────── System messages ────────────────────────────
+
+    private suspend fun insertSystemMessage(convId: String, text: String) {
+        val systemMsg = Message(
+            id = text.hashCode() + Clock.System.now().toEpochMilliseconds().toInt(),
+            serverId = "system_${Clock.System.now().toEpochMilliseconds()}",
+            text = text,
+            isOutgoing = false,
+            timestamp = Clock.System.now().toEpochMilliseconds(),
+            status = MessageStatus.SENT,
+            type = "system"
+        )
+        chatRepository.saveMessage(systemMsg, convId)
     }
 
     // ───────────────────────── Polling fallback ─────────────────────────
@@ -288,8 +342,12 @@ class ChatViewModel(
             println("MemegramDebug [Poll]: найдено ${newMessages.size} новых сообщений")
 
             val newSenders = mutableMapOf<String, String>()
+            val newReplyCtx = mutableMapOf<String, String>()
             for (msg in newMessages) {
                 newSenders[msg.id] = msg.effectiveSenderId
+                if (!msg.replyToMessageId.isNullOrBlank()) {
+                    newReplyCtx[msg.id] = msg.replyToMessageId
+                }
                 decryptAndSave(
                     convId        = conversationId,
                     msgId         = msg.id,
@@ -299,6 +357,9 @@ class ChatViewModel(
                 )
             }
             _messageSenders.update { it + newSenders }
+            if (newReplyCtx.isNotEmpty()) {
+                _replyContext.update { it + newReplyCtx }
+            }
         } catch (_: Exception) { }
     }
 
@@ -420,6 +481,9 @@ class ChatViewModel(
 
     private suspend fun sendTextMessageInternal(convId: String, text: String) {
         val now = Clock.System.now().toEpochMilliseconds()
+        val replyTo = _replyingTo.value
+        _replyingTo.value = null
+
         val tempMsg = Message(
             id = now.hashCode(), text = text, isOutgoing = true,
             timestamp = now, status = MessageStatus.SENDING, type = "text"
@@ -428,7 +492,7 @@ class ChatViewModel(
 
         try {
             if (!mlsManager.hasGroup(convId)) {
-                chatRepository.saveMessage(tempMsg.copy(text = "⚠️ Шифрование не готово", status = MessageStatus.FAILED), convId)
+                chatRepository.saveMessage(tempMsg.copy(text = S.current.encryptionNotReady, status = MessageStatus.FAILED), convId)
                 return
             }
             val ciphertextB64 = mlsManager.encrypt(convId, text)
@@ -438,21 +502,26 @@ class ChatViewModel(
                 request = SendMessageRequest(
                     mlsCiphertextB64 = ciphertextB64,
                     type = "text",
-                    clientMessageId = generateUuid()
+                    clientMessageId = generateUuid(),
+                    replyToMessageId = replyTo?.serverId
                 )
             )
-            chatRepository.saveMessage(
-                tempMsg.copy(serverId = response.messageId, status = MessageStatus.SENT), convId
-            )
+            val sentMsg = tempMsg.copy(serverId = response.messageId, status = MessageStatus.SENT)
+            chatRepository.saveMessage(sentMsg, convId)
+            if (replyTo != null && replyTo.serverId.isNotBlank()) {
+                _replyContext.update { it + (response.messageId to replyTo.serverId) }
+            }
         } catch (e: Exception) {
             chatRepository.saveMessage(tempMsg.copy(status = MessageStatus.FAILED), convId)
-            _error.value = "Ошибка отправки: ${e.message}"
+            _error.value = S.current.sendError(e.message ?: "")
         }
     }
 
     private suspend fun sendPhotoMessageInternal(convId: String, item: AttachItem, caption: String = "") {
         val now = Clock.System.now().toEpochMilliseconds()
         val previewBytes = runCatching { item.readUploadBytes() }.getOrNull()
+        val replyTo = _replyingTo.value
+        _replyingTo.value = null
 
         val tempMsg = Message(
             id = now.hashCode(), text = caption, isOutgoing = true,
@@ -463,7 +532,7 @@ class ChatViewModel(
 
         try {
             if (!mlsManager.hasGroup(convId)) {
-                chatRepository.saveMessage(tempMsg.copy(status = MessageStatus.FAILED, text = "⚠️ Шифрование не готово"), convId)
+                chatRepository.saveMessage(tempMsg.copy(status = MessageStatus.FAILED, text = S.current.encryptionNotReady), convId)
                 return
             }
 
@@ -492,7 +561,8 @@ class ChatViewModel(
                     mlsCiphertextB64 = ciphertextB64,
                     type             = "image",
                     clientMessageId  = generateUuid(),
-                    mediaId          = initResp.mediaId
+                    mediaId          = initResp.mediaId,
+                    replyToMessageId = replyTo?.serverId
                 )
             )
 
@@ -506,12 +576,15 @@ class ChatViewModel(
                 ),
                 convId
             )
+            if (replyTo != null && replyTo.serverId.isNotBlank()) {
+                _replyContext.update { it + (response.messageId to replyTo.serverId) }
+            }
         } catch (e: Exception) {
             println("MemegramDebug [Photo] ❌ FATAL: ${e::class.simpleName}: ${e.message}")
             chatRepository.saveMessage(
-                tempMsg.copy(status = MessageStatus.FAILED, text = "❌ Ошибка отправки фото"), convId
+                tempMsg.copy(status = MessageStatus.FAILED, text = S.current.photoSendError), convId
             )
-            _error.value = "Ошибка отправки фото: ${e.message}"
+            _error.value = S.current.photoSendErrorDetail(e.message ?: "")
         }
     }
 
@@ -532,7 +605,7 @@ class ChatViewModel(
 
             try {
                 if (!mlsManager.hasGroup(convId)) {
-                    chatRepository.saveMessage(tempMsg.copy(status = MessageStatus.FAILED, text = "⚠️ Шифрование не готово"), convId)
+                    chatRepository.saveMessage(tempMsg.copy(status = MessageStatus.FAILED, text = S.current.encryptionNotReady), convId)
                     return@launch
                 }
 
@@ -580,7 +653,7 @@ class ChatViewModel(
             } catch (e: Exception) {
                 println("MemegramDebug [Voice]: 🚨 КРИТИЧЕСКАЯ ОШИБКА ОТПРАВКИ: ${e.message}")
                 chatRepository.saveMessage(tempMsg.copy(status = MessageStatus.FAILED), convId)
-                _error.value = "Ошибка отправки голосового: ${e.message}"
+                _error.value = S.current.voiceSendError(e.message ?: "")
             }
         }
     }
@@ -707,6 +780,25 @@ class ChatViewModel(
     fun clearMessages() {
         val convId = currentConversationId ?: return
         viewModelScope.launch { chatRepository.deleteMessages(convId) }
+    }
+
+    fun setReplyTo(message: Message?) { _replyingTo.value = message }
+    fun clearReply() { _replyingTo.value = null }
+
+    fun deleteMessage(message: Message) {
+        val convId = currentConversationId ?: return
+        if (message.serverId.isBlank()) return
+        viewModelScope.launch {
+            try {
+                api.deleteMessage(message.serverId, deleteForEveryone = true)
+                chatRepository.saveMessage(
+                    message.copy(text = S.current.messageDeleted, type = "text", mediaId = null),
+                    convId
+                )
+            } catch (e: Exception) {
+                _error.value = S.current.deleteError(e.message ?: "")
+            }
+        }
     }
 
     private fun parseMlsPayload(payload: String): Triple<String, String, String> {

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatsScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatsScreen.kt
@@ -38,7 +38,11 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.number
 import kotlinx.datetime.toLocalDateTime
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
+import com.example.memegram.audio.GlobalAudioPlayer
+import com.example.memegram.audio.VoicePlaybackBar
+import com.example.memegram.localization.LocalStrings
 import kotlin.time.Clock
 import kotlin.time.Instant
 
@@ -61,8 +65,12 @@ fun ChatsScreen(
     profileViewModel: ProfileViewModel
 ) {
     val topBarTextColor = if (topBarColor.luminance() > 0.5f) Color.Black else Color.White
+    val s = LocalStrings.current
     val chats by viewModel.chats.collectAsState()
     val searchQuery by viewModel.searchQuery.collectAsState()
+
+    val globalAudioPlayer = koinInject<GlobalAudioPlayer>()
+    val audioPlaybackState by globalAudioPlayer.state.collectAsState()
 
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
@@ -142,49 +150,49 @@ fun ChatsScreen(
                 Spacer(Modifier.height(8.dp))
 
                 NavigationDrawerItem(
-                    label = { Text("Внешний вид") },
+                    label = { Text(s.settingsAppearance) },
                     icon = { Icon(Icons.Default.Palette, null) },
                     selected = false,
                     onClick = { scope.launch { drawerState.close(); onAppearanceClick() } },
                     modifier = Modifier.padding(horizontal = 12.dp)
                 )
                 NavigationDrawerItem(
-                    label = { Text("Уведомления") },
+                    label = { Text(s.settingsNotifications) },
                     icon = { Icon(Icons.Default.Notifications, null) },
                     selected = false,
                     onClick = { scope.launch { drawerState.close(); onNotificationsClick() } },
                     modifier = Modifier.padding(horizontal = 12.dp)
                 )
                 NavigationDrawerItem(
-                    label = { Text("Конфиденциальность") },
+                    label = { Text(s.settingsPrivacy) },
                     icon = { Icon(Icons.Default.Lock, null) },
                     selected = false,
                     onClick = { scope.launch { drawerState.close(); onPrivacyClick() } },
                     modifier = Modifier.padding(horizontal = 12.dp)
                 )
                 NavigationDrawerItem(
-                    label = { Text("Данные и память") },
+                    label = { Text(s.settingsDataAndStorage) },
                     icon = { Icon(Icons.Default.Storage, null) },
                     selected = false,
                     onClick = { scope.launch { drawerState.close(); onStorageClick() } },
                     modifier = Modifier.padding(horizontal = 12.dp)
                 )
                 NavigationDrawerItem(
-                    label = { Text("Контакты") },
+                    label = { Text(s.settingsContacts) },
                     icon = { Icon(Icons.Default.People, null) },
                     selected = false,
                     onClick = { scope.launch { drawerState.close() }; onContactsClick() },
                     modifier = Modifier.padding(horizontal = 12.dp)
                 )
                 NavigationDrawerItem(
-                    label   = { Text("Связанные устройства") },
+                    label   = { Text(s.settingsLinkedDevices) },
                     icon    = { Icon(Icons.Default.Devices, null) },
                     selected = false,
                     onClick = { scope.launch { drawerState.close() }; onLinkedDevicesClick() },
                     modifier = Modifier.padding(horizontal = 12.dp)
                 )
                 NavigationDrawerItem(
-                    label = { Text("Язык") },
+                    label = { Text(s.settingsLanguage) },
                     icon = { Icon(Icons.Default.Language, null) },
                     selected = false,
                     onClick = { scope.launch { drawerState.close(); onLanguageClick() } },
@@ -224,7 +232,7 @@ fun ChatsScreen(
                                         .focusRequester(focusRequester),
                                     decorationBox = { inner ->
                                         if (searchQuery.isEmpty()) {
-                                            Text("Поиск...", color = topBarTextColor.copy(alpha = 0.6f), fontSize = 16.sp)
+                                            Text(s.searchPlaceholder, color = topBarTextColor.copy(alpha = 0.6f), fontSize = 16.sp)
                                         }
                                         inner()
                                     }
@@ -259,7 +267,7 @@ fun ChatsScreen(
                                     onDismissRequest = { showAddMenu = false }
                                 ) {
                                     DropdownMenuItem(
-                                        text = { Text("Создать группу") },
+                                        text = { Text(s.createGroup) },
                                         onClick = {
                                             showAddMenu = false
                                             onNavigateToCreateGroup()
@@ -267,7 +275,7 @@ fun ChatsScreen(
                                         leadingIcon = { Icon(Icons.Default.Group, null) }
                                     )
                                     DropdownMenuItem(
-                                        text = { Text("Добавить по ключу") },
+                                        text = { Text(s.addByKey) },
                                         onClick = {
                                             showAddMenu = false
                                             showAddKeyDialog = true
@@ -275,12 +283,12 @@ fun ChatsScreen(
                                         leadingIcon = { Icon(Icons.Default.Key, null) }
                                     )
                                     DropdownMenuItem(
-                                        text = { Text("Добавить по QR") },
+                                        text = { Text(s.addByQr) },
                                         onClick = { showAddMenu = false },
                                         leadingIcon = { Icon(Icons.Default.QrCodeScanner, null) }
                                     )
                                     DropdownMenuItem(
-                                        text = { Text("Создать канал") },
+                                        text = { Text(s.createChannel) },
                                         onClick = { showAddMenu = false },
                                         leadingIcon = { Icon(Icons.Default.Campaign, null) }
                                     )
@@ -296,15 +304,15 @@ fun ChatsScreen(
                 if (showAddKeyDialog) {
                     AlertDialog(
                         onDismissRequest = { showAddKeyDialog = false },
-                        title = { Text("Новый чат") },
+                        title = { Text(s.newChat) },
                         text = {
                             Column {
-                                Text("Введите публичный ключ пользователя, чтобы добавить его в контакты и сразу начать чат.", style = MaterialTheme.typography.bodySmall)
+                                Text(s.enterPublicKeyToChat, style = MaterialTheme.typography.bodySmall)
                                 Spacer(Modifier.height(8.dp))
                                 OutlinedTextField(
                                     value = newKeyInput,
                                     onValueChange = { newKeyInput = it },
-                                    label = { Text("Публичный ключ") },
+                                    label = { Text(s.publicKey) },
                                     modifier = Modifier.fillMaxWidth()
                                 )
                             }
@@ -319,36 +327,50 @@ fun ChatsScreen(
                                     newKeyInput = ""
                                 }
                             ) {
-                                Text("Начать")
+                                Text(s.start)
                             }
                         },
                         dismissButton = {
                             TextButton(onClick = { showAddKeyDialog = false }) {
-                                Text("Отмена")
+                                Text(s.cancel)
                             }
                         }
                     )
                 }
             }
         ) { paddingValues ->
-            Box(
+            Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background)
                     .padding(paddingValues)
             ) {
-                if (chats.isEmpty() && searchQuery.isNotBlank()) {
-                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        Text("Ничего не найдено", color = Color.Gray)
-                    }
-                } else {
-                    LazyColumn(Modifier.fillMaxSize()) {
-                        items(chats, key = { it.id }) { chat ->
-                            ChatItem(chat = chat, onClick = { onChatClick(chat) })
-                            HorizontalDivider(
-                                modifier = Modifier.padding(start = 76.dp),
-                                color = MaterialTheme.colorScheme.surfaceVariant
-                            )
+                VoicePlaybackBar(
+                    state = audioPlaybackState,
+                    onTogglePlayPause = { globalAudioPlayer.togglePlayPause() },
+                    onSeek = { globalAudioPlayer.seekTo(it) },
+                    onClose = { globalAudioPlayer.stop() },
+                    accentColor = topBarColor
+                )
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .background(MaterialTheme.colorScheme.background)
+                ) {
+                    if (chats.isEmpty() && searchQuery.isNotBlank()) {
+                        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            Text(s.nothingFound, color = Color.Gray)
+                        }
+                    } else {
+                        LazyColumn(Modifier.fillMaxSize()) {
+                            items(chats, key = { it.id }) { chat ->
+                                ChatItem(chat = chat, onClick = { onChatClick(chat) })
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(start = 76.dp),
+                                    color = MaterialTheme.colorScheme.surfaceVariant
+                                )
+                            }
                         }
                     }
                 }
@@ -373,6 +395,7 @@ fun formatChatTime(timestampMs: Long): String {
 
 @Composable
 fun ChatItem(chat: ChatModel, onClick: () -> Unit) {
+    val s = LocalStrings.current
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -426,7 +449,7 @@ fun ChatItem(chat: ChatModel, onClick: () -> Unit) {
                     Spacer(modifier = Modifier.width(6.dp))
                 } else if (chat.isLastMessageMine) {
                     Text(
-                        text = "Вы: ",
+                        text = s.youPrefix,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.primary,
                         fontWeight = FontWeight.Medium

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatsViewModel.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatsViewModel.kt
@@ -277,6 +277,22 @@ class ChatsViewModel(
                     handleMemberLeftRemoval(convId, leftUserId)
                 }
             }
+            "member_kicked" -> {
+                val kickedUserId = event.data?.userId
+                val myUserId = sessionManager.getUserId()
+                if (kickedUserId == null) return
+
+                if (kickedUserId == myUserId) {
+                    handleSelfKicked(convId)
+                } else if (mlsManager.hasGroup(convId)) {
+                    handleMemberLeftRemoval(convId, kickedUserId)
+                }
+            }
+            "role_changed" -> {
+                val userId = event.data?.userId
+                val newRole = event.data?.newRole
+                println("MemegramDebug [ChatsVM]: role_changed: user=$userId, newRole=$newRole in conv=$convId")
+            }
         }
     }
 
@@ -338,6 +354,23 @@ class ChatsViewModel(
                 }
             } catch (e: Exception) {
                 println("MemegramDebug [ChatsVM]: handleMemberLeftRemoval error: ${e.message}")
+            }
+        }
+    }
+
+    private fun handleSelfKicked(conversationId: String) {
+        viewModelScope.launch {
+            try {
+                println("MemegramDebug [ChatsVM]: I was kicked from conv=$conversationId — cleaning up")
+
+                try { mlsManager.deleteLocalGroup(conversationId) } catch (_: Exception) {}
+
+                chatRepository.deleteChat(conversationId)
+                mlsManager.flushState()
+
+                println("MemegramDebug [ChatsVM]: ✅ Self-kick cleanup done for conv=$conversationId")
+            } catch (e: Exception) {
+                println("MemegramDebug [ChatsVM]: handleSelfKicked error: ${e.message}")
             }
         }
     }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ContactsScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ContactsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.memegram.data.models.ContactEntry
+import com.example.memegram.localization.LocalStrings
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -31,6 +32,7 @@ fun ContactsScreen(
     viewModel: ContactsViewModel
 ) {
     val topBarTextColor = if (topBarColor.luminance() > 0.5f) Color.Black else Color.White
+    val s = LocalStrings.current
     val contacts by viewModel.contacts.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
     val isAdding by viewModel.isAdding.collectAsState()
@@ -55,7 +57,7 @@ fun ContactsScreen(
     LaunchedEffect(chatCreated) {
         val conversationId = chatCreated
         if (conversationId != null) {
-            val chatName = viewModel.getPendingChatName() ?: "Чат"
+            val chatName = viewModel.getPendingChatName() ?: s.chatFallback
             viewModel.clearChatCreated()
             viewModel.clearPendingChatName()
             onChatClick(
@@ -72,7 +74,7 @@ fun ContactsScreen(
     error?.let { msg ->
         AlertDialog(
             onDismissRequest = viewModel::clearError,
-            title = { Text("Ошибка") },
+            title = { Text(s.error) },
             text = { Text(msg) },
             confirmButton = { TextButton(onClick = viewModel::clearError) { Text("OK") } }
         )
@@ -81,11 +83,11 @@ fun ContactsScreen(
     if (showAddDialog) {
         AlertDialog(
             onDismissRequest = { if (!isAdding) showAddDialog = false },
-            title = { Text("Новый контакт") },
+            title = { Text(s.newContact) },
             text = {
                 Column {
                     Text(
-                        "Введите публичный ключ пользователя",
+                        s.enterPublicKey,
                         fontSize = 13.sp,
                         color = Color.Gray,
                         modifier = Modifier.padding(bottom = 12.dp)
@@ -93,7 +95,7 @@ fun ContactsScreen(
                     OutlinedTextField(
                         value = publicKeyInput,
                         onValueChange = { publicKeyInput = it },
-                        label = { Text("Публичный ключ") },
+                        label = { Text(s.publicKey) },
                         singleLine = true,
                         shape = RoundedCornerShape(12.dp),
                         modifier = Modifier.fillMaxWidth(),
@@ -118,7 +120,7 @@ fun ContactsScreen(
                             color = Color.White
                         )
                     } else {
-                        Text("Добавить")
+                        Text(s.add)
                     }
                 }
             },
@@ -126,7 +128,7 @@ fun ContactsScreen(
                 TextButton(
                     onClick = { showAddDialog = false; publicKeyInput = "" },
                     enabled = !isAdding
-                ) { Text("Отмена") }
+                ) { Text(s.cancel) }
             }
         )
     }
@@ -136,18 +138,18 @@ fun ContactsScreen(
             ?.profile?.username ?: (userId.take(8) + "...")
         AlertDialog(
             onDismissRequest = { pendingRemoveId = null },
-            title = { Text("Удалить контакт?") },
-            text = { Text("Удалить $name из контактов?") },
+            title = { Text(s.deleteContactTitle) },
+            text = { Text(s.deleteContactMessage(name)) },
             confirmButton = {
                 TextButton(
                     onClick = { viewModel.removeContact(userId); pendingRemoveId = null },
                     colors = ButtonDefaults.textButtonColors(
                         contentColor = MaterialTheme.colorScheme.error
                     )
-                ) { Text("Удалить") }
+                ) { Text(s.delete) }
             },
             dismissButton = {
-                TextButton(onClick = { pendingRemoveId = null }) { Text("Отмена") }
+                TextButton(onClick = { pendingRemoveId = null }) { Text(s.cancel) }
             }
         )
     }
@@ -157,18 +159,18 @@ fun ContactsScreen(
             ?.profile?.username ?: (userId.take(8) + "...")
         AlertDialog(
             onDismissRequest = { pendingBlockId = null },
-            title = { Text("Заблокировать?") },
-            text = { Text("Заблокировать $name? Он будет удалён из контактов.") },
+            title = { Text(s.blockTitle) },
+            text = { Text(s.blockMessage(name)) },
             confirmButton = {
                 TextButton(
                     onClick = { viewModel.blockUser(userId); pendingBlockId = null },
                     colors = ButtonDefaults.textButtonColors(
                         contentColor = MaterialTheme.colorScheme.error
                     )
-                ) { Text("Заблокировать") }
+                ) { Text(s.blockAction) }
             },
             dismissButton = {
-                TextButton(onClick = { pendingBlockId = null }) { Text("Отмена") }
+                TextButton(onClick = { pendingBlockId = null }) { Text(s.cancel) }
             }
         )
     }
@@ -176,7 +178,7 @@ fun ContactsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Контакты") },
+                title = { Text(s.contactsTitle) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = topBarTextColor)
@@ -219,13 +221,13 @@ fun ContactsScreen(
                         )
                         Spacer(Modifier.height(12.dp))
                         Text(
-                            "Нет контактов",
+                            s.noContacts,
                             style = MaterialTheme.typography.titleMedium,
                             color = Color.Gray
                         )
                         Spacer(Modifier.height(4.dp))
                         Text(
-                            "Нажмите + чтобы добавить контакт\nпо публичному ключу",
+                            s.addContactHint,
                             fontSize = 13.sp,
                             color = Color.Gray,
                             textAlign = TextAlign.Center,
@@ -240,7 +242,7 @@ fun ContactsScreen(
 
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
                         if (favorites.isNotEmpty()) {
-                            item { SectionHeader("⭐ Избранные", topBarColor) }
+                            item { SectionHeader(s.favorites, topBarColor) }
                             items(favorites, key = { it.contactUserId }) { entry ->
                                 ContactItem(
                                     entry = entry,
@@ -262,7 +264,7 @@ fun ContactsScreen(
                         }
 
                         if (others.isNotEmpty()) {
-                            item { SectionHeader("Все контакты", topBarColor) }
+                            item { SectionHeader(s.allContacts, topBarColor) }
                             items(others, key = { it.contactUserId }) { entry ->
                                 ContactItem(
                                     entry = entry,
@@ -312,6 +314,7 @@ private fun ContactItem(
     val displayName = entry.profile?.username
         ?.takeIf { it.isNotBlank() }
         ?: "@${entry.contactUserId.take(8)}"
+    val s = LocalStrings.current
     var showMenu by remember { mutableStateOf(false) }
 
     Row(
@@ -370,7 +373,7 @@ private fun ContactItem(
             ) {
                 DropdownMenuItem(
                     text = {
-                        Text(if (entry.isFavorite) "Убрать из избранного" else "В избранное")
+                        Text(if (entry.isFavorite) s.removeFromFavorites else s.addToFavorites)
                     },
                     leadingIcon = {
                         Icon(
@@ -382,7 +385,7 @@ private fun ContactItem(
                     onClick = { onFavoriteToggle(); showMenu = false }
                 )
                 DropdownMenuItem(
-                    text = { Text("Удалить", color = MaterialTheme.colorScheme.error) },
+                    text = { Text(s.delete, color = MaterialTheme.colorScheme.error) },
                     leadingIcon = {
                         Icon(
                             Icons.Default.PersonRemove,
@@ -393,7 +396,7 @@ private fun ContactItem(
                     onClick = { onRemove(); showMenu = false }
                 )
                 DropdownMenuItem(
-                    text = { Text("Заблокировать", color = MaterialTheme.colorScheme.error) },
+                    text = { Text(s.blockAction, color = MaterialTheme.colorScheme.error) },
                     leadingIcon = {
                         Icon(
                             Icons.Default.Block,

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ContactsViewModel.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ContactsViewModel.kt
@@ -98,6 +98,32 @@ class ContactsViewModel(
     fun resetAddSuccess() { _addSuccess.value = false }
     fun clearError() { _error.value = null }
 
+    /**
+     * Attempt to commit a group change. If the server rejects it with an epoch
+     * conflict (e.g. "expected 2, got 1"), parse the expected epoch and retry
+     * once with the corrected value.
+     * Returns the actual epoch after a successful commit.
+     */
+    private suspend fun commitGroupChangeWithRetry(
+        convId: String,
+        request: CommitGroupChangeRequest
+    ): Long {
+        return try {
+            api.commitGroupChange(convId, request)
+            request.newEpoch.toLong()
+        } catch (e: Exception) {
+            val expected = Regex("""expected\s+(\d+)""")
+                .find(e.message ?: "")?.groupValues?.get(1)?.toLongOrNull()
+            if (expected != null && expected > request.newEpoch) {
+                println("MemegramDebug [MLS] Epoch conflict retry: ${request.newEpoch} → $expected for conv=$convId")
+                api.commitGroupChange(convId, request.copy(newEpoch = expected.toInt()))
+                expected
+            } else {
+                throw e
+            }
+        }
+    }
+
     private val _pendingChatContact = MutableStateFlow<String?>(null)
 
     fun startDirectChatWith(entry: ContactEntry) {
@@ -139,8 +165,8 @@ class ContactsViewModel(
                 )
 
                 mlsManager.bindConversation(conv.id, mlsGroupId)
+
                 var currentEpoch = 0L
-                mlsManager.updateGroupEpoch(conv.id, currentEpoch)
 
                 for (kp in allPackagesToAdd) {
                     try {
@@ -149,7 +175,7 @@ class ContactsViewModel(
 
                         val nextEpoch = currentEpoch + 1L
 
-                        api.commitGroupChange(
+                        val actualEpoch = commitGroupChangeWithRetry(
                             conv.id,
                             CommitGroupChangeRequest(
                                 commitData = addResult.commitB64,
@@ -161,7 +187,7 @@ class ContactsViewModel(
                             )
                         )
                         mlsManager.mergePendingCommit(conv.id)
-                        currentEpoch = nextEpoch
+                        currentEpoch = actualEpoch
                         mlsManager.updateGroupEpoch(conv.id, currentEpoch)
                     } catch (e: Exception) {
                         println("MemegramDebug [MLS] ❌ Ошибка добавления устройства ${kp.deviceId}: ${e.message}")
@@ -243,8 +269,8 @@ class ContactsViewModel(
                 )
 
                 mlsManager.bindConversation(conv.id, mlsGroupId)
+
                 var currentEpoch = 0L
-                mlsManager.updateGroupEpoch(conv.id, currentEpoch)
 
                 for (device in allDevicesToInvite) {
                     try {
@@ -253,7 +279,7 @@ class ContactsViewModel(
 
                         val nextEpoch = currentEpoch + 1L
 
-                        api.commitGroupChange(
+                        val actualEpoch = commitGroupChangeWithRetry(
                             conv.id,
                             CommitGroupChangeRequest(
                                 commitData = addResult.commitB64,
@@ -269,7 +295,7 @@ class ContactsViewModel(
                         )
 
                         mlsManager.mergePendingCommit(conv.id)
-                        currentEpoch = nextEpoch
+                        currentEpoch = actualEpoch
                         mlsManager.updateGroupEpoch(conv.id, currentEpoch)
                     } catch (e: Exception) {
                         println("MemegramDebug [MLS] ❌ Ошибка добавления устройства ${device.second.deviceId}: ${e.message}")
@@ -341,8 +367,8 @@ class ContactsViewModel(
                 )
 
                 mlsManager.bindConversation(conv.id, mlsGroupId)
+
                 var currentEpoch = 0L
-                mlsManager.updateGroupEpoch(conv.id, currentEpoch)
 
                 for (kp in allPackagesToAdd) {
                     try {
@@ -350,7 +376,7 @@ class ContactsViewModel(
                         mlsManager.flushState()
 
                         val nextEpoch = currentEpoch + 1L
-                        api.commitGroupChange(
+                        val actualEpoch = commitGroupChangeWithRetry(
                             conv.id,
                             CommitGroupChangeRequest(
                                 commitData = addResult.commitB64,
@@ -360,7 +386,7 @@ class ContactsViewModel(
                             )
                         )
                         mlsManager.mergePendingCommit(conv.id)
-                        currentEpoch = nextEpoch
+                        currentEpoch = actualEpoch
                         mlsManager.updateGroupEpoch(conv.id, currentEpoch)
                     } catch (e: Exception) {
                         println("MemegramDebug [MLS] ❌ Ошибка добавления устройства ${kp.deviceId}: ${e.message}")

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/CreateGroupScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/CreateGroupScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import com.example.memegram.localization.LocalStrings
 import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -28,6 +29,7 @@ fun CreateGroupScreen(
     val isCreating by vm.isCreatingChat.collectAsState()
     val error by vm.error.collectAsState()
     val createdChatId by vm.chatCreated.collectAsState()
+    val s = LocalStrings.current
 
     var groupName by remember { mutableStateOf("") }
     val selectedUserIds = remember { mutableStateListOf<String>() }
@@ -42,10 +44,10 @@ fun CreateGroupScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Создать группу") },
+                title = { Text(s.createGroup) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Назад")
+                        Icon(Icons.Default.ArrowBack, contentDescription = s.back)
                     }
                 },
                 actions = {
@@ -53,7 +55,7 @@ fun CreateGroupScreen(
                         onClick = { vm.createGroupChat(groupName, selectedUserIds) },
                         enabled = groupName.isNotBlank() && selectedUserIds.isNotEmpty() && !isCreating
                     ) {
-                        Icon(Icons.Default.Check, contentDescription = "Создать", tint = MaterialTheme.colorScheme.primary)
+                        Icon(Icons.Default.Check, contentDescription = s.create, tint = MaterialTheme.colorScheme.primary)
                     }
                 }
             )
@@ -75,7 +77,7 @@ fun CreateGroupScreen(
             OutlinedTextField(
                 value = groupName,
                 onValueChange = { groupName = it },
-                label = { Text("Название группы") },
+                label = { Text(s.groupName) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 8.dp),
@@ -84,7 +86,7 @@ fun CreateGroupScreen(
             )
 
             Text(
-                text = "Участники (${selectedUserIds.size} выбрано)",
+                text = s.membersSelected(selectedUserIds.size),
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp)
@@ -96,7 +98,7 @@ fun CreateGroupScreen(
                 }
             } else if (contacts.isEmpty()) {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text("У вас пока нет контактов", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text(s.noContactsYet, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             } else {
                 LazyColumn {

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/DateScrubber.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/DateScrubber.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.memegram.data.gallery.GallerySection
+import com.example.memegram.localization.S
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
@@ -130,13 +131,13 @@ fun formatChatTimestamp(timestampMs: Long): String {
         }
         msgDay >= today.minus(6, DateTimeUnit.DAY) -> {
             when (msgLocal.dayOfWeek) {
-                DayOfWeek.MONDAY    -> "Пн"
-                DayOfWeek.TUESDAY   -> "Вт"
-                DayOfWeek.WEDNESDAY -> "Ср"
-                DayOfWeek.THURSDAY  -> "Чт"
-                DayOfWeek.FRIDAY    -> "Пт"
-                DayOfWeek.SATURDAY  -> "Сб"
-                DayOfWeek.SUNDAY    -> "Вс"
+                DayOfWeek.MONDAY    -> S.current.mon
+                DayOfWeek.TUESDAY   -> S.current.tue
+                DayOfWeek.WEDNESDAY -> S.current.wed
+                DayOfWeek.THURSDAY  -> S.current.thu
+                DayOfWeek.FRIDAY    -> S.current.fri
+                DayOfWeek.SATURDAY  -> S.current.sat
+                DayOfWeek.SUNDAY    -> S.current.sun
             }
         }
         msgDay.year == today.year -> {

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/GroupProfileScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/GroupProfileScreen.kt
@@ -1,7 +1,9 @@
 package com.example.memegram
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -20,8 +22,16 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.memegram.localization.AppStrings
+import com.example.memegram.localization.LocalStrings
 
-@OptIn(ExperimentalMaterial3Api::class)
+private fun roleDisplayName(role: String, s: AppStrings): String = when (role) {
+    "owner" -> s.roleOwner
+    "admin" -> s.roleAdmin
+    else    -> s.roleMember
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun GroupProfileScreen(
     topBarColor: Color,
@@ -29,21 +39,40 @@ fun GroupProfileScreen(
     groupName: String,
     onBack: () -> Unit,
     onLeaveSuccess: () -> Unit,
+    onNavigateToChat: (conversationId: String, chatName: String) -> Unit = { _, _ -> },
     viewModel: GroupProfileViewModel,
     contactsViewModel: ContactsViewModel
 ) {
     val topBarTextColor = if (topBarColor.luminance() > 0.5f) Color.Black else Color.White
+    val s = LocalStrings.current
     val members by viewModel.filteredMembers.collectAsState()
     val searchQuery by viewModel.searchQuery.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
+    val myRole by viewModel.myRole.collectAsState()
     val contacts by contactsViewModel.contacts.collectAsState()
     var selectedContactId by remember { mutableStateOf<String?>(null) }
     var showLeaveConfirm by remember { mutableStateOf(false) }
     var showAddMemberDialog by remember { mutableStateOf(false) }
     var newMemberKey by remember { mutableStateOf("") }
 
+    var contextMenuMember by remember { mutableStateOf<GroupMemberUI?>(null) }
+    var showKickConfirm by remember { mutableStateOf(false) }
+    var kickTargetMember by remember { mutableStateOf<GroupMemberUI?>(null) }
+    var dmTargetName by remember { mutableStateOf(s.chatFallback) }
+
+    val isAdmin = myRole == "owner" || myRole == "admin"
+    val isOwner = myRole == "owner"
+
     LaunchedEffect(conversationId) {
         viewModel.loadGroup(conversationId)
+    }
+
+    val createdChatId by contactsViewModel.chatCreated.collectAsState()
+    LaunchedEffect(createdChatId) {
+        createdChatId?.let { id ->
+            contactsViewModel.clearChatCreated()
+            onNavigateToChat(id, dmTargetName)
+        }
     }
 
     val error by viewModel.error.collectAsState()
@@ -53,11 +82,12 @@ fun GroupProfileScreen(
         error?.let { snackbarHostState.showSnackbar(it) }
     }
 
+    // ── Leave confirmation ───────────────────────
     if (showLeaveConfirm) {
         AlertDialog(
             onDismissRequest = { showLeaveConfirm = false },
-            title = { Text("Покинуть группу?") },
-            text = { Text("Вы больше не будете получать сообщения из этого чата.") },
+            title = { Text(s.leaveGroupTitle) },
+            text = { Text(s.leaveGroupMessage) },
             confirmButton = {
                 TextButton(
                     onClick = {
@@ -65,30 +95,127 @@ fun GroupProfileScreen(
                         viewModel.leaveGroup(conversationId, onLeaveSuccess)
                     },
                     colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
-                ) { Text("Покинуть") }
+                ) { Text(s.leave) }
             },
             dismissButton = {
-                TextButton(onClick = { showLeaveConfirm = false }) { Text("Отмена") }
+                TextButton(onClick = { showLeaveConfirm = false }) { Text(s.cancel) }
             }
         )
     }
 
+    // ── Kick confirmation ────────────────────────
+    if (showKickConfirm && kickTargetMember != null) {
+        val target = kickTargetMember!!
+        AlertDialog(
+            onDismissRequest = { showKickConfirm = false; kickTargetMember = null },
+            title = { Text(s.removeMemberTitle) },
+            text = { Text(s.removeMemberMessage(target.user.username ?: s.userFallback)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showKickConfirm = false
+                        viewModel.kickMember(conversationId, target.user.id)
+                        kickTargetMember = null
+                    },
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
+                ) { Text(s.remove) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showKickConfirm = false; kickTargetMember = null }) { Text(s.cancel) }
+            }
+        )
+    }
+
+    // ── Member context menu (long-press) ─────────
+    contextMenuMember?.let { member ->
+        val isSelf = member.user.id == viewModel.currentUserId
+        val canKick = isAdmin && member.role != "owner" && (isOwner || member.role != "admin") && !isSelf
+        val canPromote = isAdmin && member.role == "member" && !isSelf
+        val canDemote = isOwner && member.role == "admin" && !isSelf
+        val isAlreadyContact = contacts.any { it.contactUserId == member.user.id }
+
+        AlertDialog(
+            onDismissRequest = { contextMenuMember = null },
+            title = { Text(member.user.username ?: s.member) },
+            text = {
+                Column {
+                    if (!isSelf) {
+                        TextButton(
+                            onClick = {
+                                val targetName = member.user.username ?: s.chatFallback
+                                contextMenuMember = null
+                                dmTargetName = targetName
+                                contactsViewModel.startDirectChatByUserId(member.user.id)
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                        ) { Text(s.sendDM, modifier = Modifier.fillMaxWidth()) }
+
+                        if (!isAlreadyContact && member.user.userPublicKey != null) {
+                            TextButton(
+                                onClick = {
+                                    contextMenuMember = null
+                                    contactsViewModel.addContact(member.user.userPublicKey!!)
+                                },
+                                modifier = Modifier.fillMaxWidth()
+                            ) { Text(s.addToContacts, modifier = Modifier.fillMaxWidth()) }
+                        }
+                    }
+
+                    if (canPromote) {
+                        TextButton(
+                            onClick = {
+                                contextMenuMember = null
+                                viewModel.updateMemberRole(conversationId, member.user.id, "admin")
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                        ) { Text(s.makeAdmin, modifier = Modifier.fillMaxWidth()) }
+                    }
+                    if (canDemote) {
+                        TextButton(
+                            onClick = {
+                                contextMenuMember = null
+                                viewModel.updateMemberRole(conversationId, member.user.id, "member")
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                        ) { Text(s.removeAdminRole, modifier = Modifier.fillMaxWidth()) }
+                    }
+                    if (canKick) {
+                        TextButton(
+                            onClick = {
+                                contextMenuMember = null
+                                kickTargetMember = member
+                                showKickConfirm = true
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
+                        ) { Text(s.removeFromGroup, modifier = Modifier.fillMaxWidth()) }
+                    }
+                }
+            },
+            confirmButton = {},
+            dismissButton = {
+                TextButton(onClick = { contextMenuMember = null }) { Text(s.cancel) }
+            }
+        )
+    }
+
+    // ── Add member dialog ────────────────────────
     if (showAddMemberDialog) {
         AlertDialog(
             onDismissRequest = { showAddMemberDialog = false; selectedContactId = null },
-            title = { Text("Выберите участника") },
+            title = { Text(s.selectMember) },
             text = {
                 val availableContacts = contacts.filter { c ->
                     members.none { m -> m.user.id == c.contactUserId }
                 }
 
                 if (availableContacts.isEmpty()) {
-                    Text("Нет доступных контактов для добавления", color = Color.Gray)
+                    Text(s.noAvailableContacts, color = Color.Gray)
                 } else {
                     LazyColumn(modifier = Modifier.fillMaxHeight(0.6f)) {
                         items(availableContacts, key = { it.contactUserId }) { contact ->
                             val isSelected = selectedContactId == contact.contactUserId
-                            val name = contact.profile?.username ?: "Без имени"
+                            val name = contact.profile?.username ?: s.noName
 
                             ListItem(
                                 modifier = Modifier.clickable { selectedContactId = contact.contactUserId },
@@ -119,10 +246,10 @@ fun GroupProfileScreen(
                         selectedContactId = null
                     },
                     enabled = selectedContactId != null
-                ) { Text("Добавить") }
+                ) { Text(s.add) }
             },
             dismissButton = {
-                TextButton(onClick = { showAddMemberDialog = false; selectedContactId = null }) { Text("Отмена") }
+                TextButton(onClick = { showAddMemberDialog = false; selectedContactId = null }) { Text(s.cancel) }
             }
         )
     }
@@ -130,7 +257,7 @@ fun GroupProfileScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Информация о группе", color = topBarTextColor) },
+                title = { Text(s.groupInfo, color = topBarTextColor) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = topBarTextColor)
@@ -156,18 +283,20 @@ fun GroupProfileScreen(
                 }
                 Spacer(Modifier.height(16.dp))
                 Text(groupName, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
-                Text("${members.size} участников", color = Color.Gray, style = MaterialTheme.typography.bodyMedium)
+                Text(s.membersCount(members.size), color = Color.Gray, style = MaterialTheme.typography.bodyMedium)
             }
 
             HorizontalDivider()
 
+            if (isAdmin) {
+                ListItem(
+                    headlineContent = { Text(s.addMember, color = MaterialTheme.colorScheme.primary) },
+                    leadingContent = { Icon(Icons.Default.PersonAdd, null, tint = MaterialTheme.colorScheme.primary) },
+                    modifier = Modifier.clickable { showAddMemberDialog = true }
+                )
+            }
             ListItem(
-                headlineContent = { Text("Добавить участника", color = MaterialTheme.colorScheme.primary) },
-                leadingContent = { Icon(Icons.Default.PersonAdd, null, tint = MaterialTheme.colorScheme.primary) },
-                modifier = Modifier.clickable { showAddMemberDialog = true }
-            )
-            ListItem(
-                headlineContent = { Text("Покинуть группу", color = MaterialTheme.colorScheme.error) },
+                headlineContent = { Text(s.leaveGroup, color = MaterialTheme.colorScheme.error) },
                 modifier = Modifier.clickable { showLeaveConfirm = true }
             )
 
@@ -176,7 +305,7 @@ fun GroupProfileScreen(
             OutlinedTextField(
                 value = searchQuery,
                 onValueChange = { viewModel.updateSearchQuery(it) },
-                placeholder = { Text("Поиск участников...") },
+                placeholder = { Text(s.searchMembers) },
                 leadingIcon = { Icon(Icons.Default.Search, null) },
                 modifier = Modifier.fillMaxWidth().padding(16.dp),
                 singleLine = true,
@@ -190,9 +319,10 @@ fun GroupProfileScreen(
             } else {
                 LazyColumn(modifier = Modifier.fillMaxWidth()) {
                     items(members, key = { it.user.id }) { member ->
+                        val canInteract = member.user.id != viewModel.currentUserId
                         ListItem(
-                            headlineContent = { Text(member.user.username ?: "Без имени") },
-                            supportingContent = { Text(if (member.role == "admin") "Администратор" else "Участник") },
+                            headlineContent = { Text(member.user.username ?: s.noName) },
+                            supportingContent = { Text(roleDisplayName(member.role, s)) },
                             leadingContent = {
                                 Box(
                                     modifier = Modifier.size(40.dp).clip(CircleShape).background(MaterialTheme.colorScheme.secondaryContainer),
@@ -204,7 +334,13 @@ fun GroupProfileScreen(
                                         fontWeight = FontWeight.Bold
                                     )
                                 }
-                            }
+                            },
+                            modifier = if (canInteract) {
+                                Modifier.combinedClickable(
+                                    onClick = {},
+                                    onLongClick = { contextMenuMember = member }
+                                )
+                            } else Modifier
                         )
                     }
                 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/GroupProfileViewModel.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/GroupProfileViewModel.kt
@@ -2,6 +2,7 @@ package com.example.memegram
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.memegram.data.local.SessionManager
 import com.example.memegram.data.models.CommitGroupChangeRequest
 import com.example.memegram.data.models.DeviceWelcome
 import com.example.memegram.data.models.LeaveConversationRequest
@@ -20,10 +21,18 @@ data class GroupMemberUI(
 class GroupProfileViewModel(
     private val api: ApiService,
     private val mlsManager: MlsManager,
-    private val chatRepository: ChatRepository
+    private val chatRepository: ChatRepository,
+    private val sessionManager: SessionManager
 ) : ViewModel() {
 
     private val _members = MutableStateFlow<List<GroupMemberUI>>(emptyList())
+
+    /** The current user's role in this group (owner/admin/member). */
+    private val _myRole = MutableStateFlow("member")
+    val myRole: StateFlow<String> = _myRole.asStateFlow()
+
+    val currentUserId: String
+        get() = sessionManager.getUserId() ?: ""
 
     private val _searchQuery = MutableStateFlow("")
     val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
@@ -55,6 +64,9 @@ class GroupProfileViewModel(
                     }
                 }
                 _members.value = loadedMembers
+                val myId = currentUserId
+                val myMember = conv.members.find { it.userId == myId }
+                _myRole.value = myMember?.role ?: "member"
             } catch (e: Exception) {
                 _error.value = "Ошибка загрузки группы: ${e.message}"
             } finally {
@@ -145,6 +157,66 @@ class GroupProfileViewModel(
                 val errorMsg = e.message ?: "Неизвестная ошибка"
                 println("MemegramDebug [AddMember]: ❌ ОШИБКА: $errorMsg")
                 _error.value = "Не удалось добавить: $errorMsg"
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    fun kickMember(conversationId: String, targetUserId: String) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _error.value = null
+            try {
+                api.kickMember(conversationId, targetUserId)
+
+                if (mlsManager.hasGroup(conversationId)) {
+                    try {
+                        val serverEpochCounter = syncGroupState(conversationId)
+
+                        val commitB64 = mlsManager.removeMember(conversationId, targetUserId)
+                        mlsManager.flushState()
+
+                        val nextServerEpoch = (serverEpochCounter + 1).toInt()
+
+                        api.commitGroupChange(
+                            conversationId,
+                            CommitGroupChangeRequest(
+                                commitData = commitB64,
+                                newEpoch = nextServerEpoch,
+                                removedDeviceIds = emptyList()
+                            )
+                        )
+
+                        mlsManager.mergePendingCommit(conversationId)
+                        mlsManager.updateGroupEpoch(conversationId, nextServerEpoch.toLong())
+                        mlsManager.flushState()
+
+                        println("MemegramDebug [Kick]: ✅ MLS Remove Commit sent, epoch=$nextServerEpoch")
+                    } catch (mlsError: Exception) {
+                        println("MemegramDebug [Kick]: ⚠️ MLS Remove Commit failed (kick still valid): ${mlsError.message}")
+                        try { mlsManager.clearPendingCommit(conversationId) } catch (_: Exception) {}
+                    }
+                }
+
+                loadGroup(conversationId)
+            } catch (e: Exception) {
+                _error.value = "Ошибка при удалении участника: ${e.message}"
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    fun updateMemberRole(conversationId: String, targetUserId: String, newRole: String) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _error.value = null
+            try {
+                api.updateMemberRole(conversationId, targetUserId, newRole)
+                loadGroup(conversationId)
+            } catch (e: Exception) {
+                _error.value = "Ошибка при изменении роли: ${e.message}"
             } finally {
                 _isLoading.value = false
             }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/LanguageScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/LanguageScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.memegram.localization.LocalStrings
 
 data class Language(
     val code: String,
@@ -32,11 +33,11 @@ fun LanguageScreen(
     onBack: () -> Unit,
     viewModel: LanguageViewModel
 ) {
+    val s = LocalStrings.current
     val topBarTextColor = if (topBarColor.luminance() > 0.5f) Color.Black else Color.White
     val currentLang by viewModel.currentLang.collectAsState()
     var searchQuery by remember { mutableStateOf("") }
     var aiTranslation by remember { mutableStateOf(false) }
-    var showRestartSnackbar by remember { mutableStateOf(false) }
 
     val allLanguages = remember {
         listOf(
@@ -64,19 +65,10 @@ fun LanguageScreen(
         }
     }
 
-    val snackbarHostState = remember { SnackbarHostState() }
-
-    LaunchedEffect(showRestartSnackbar) {
-        if (showRestartSnackbar) {
-            snackbarHostState.showSnackbar("Перезапустите приложение для применения языка")
-            showRestartSnackbar = false
-        }
-    }
-
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Язык") },
+                title = { Text(s.languageTitle) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -92,8 +84,7 @@ fun LanguageScreen(
                     navigationIconContentColor = topBarTextColor
                 )
             )
-        },
-        snackbarHost = { SnackbarHost(snackbarHostState) }
+        }
     ) { paddingValues ->
         Column(
             modifier = Modifier
@@ -103,7 +94,7 @@ fun LanguageScreen(
             OutlinedTextField(
                 value = searchQuery,
                 onValueChange = { searchQuery = it },
-                placeholder = { Text("Поиск языка...") },
+                placeholder = { Text(s.searchLanguage) },
                 leadingIcon = {
                     Icon(Icons.Default.Search, contentDescription = null)
                 },
@@ -131,12 +122,12 @@ fun LanguageScreen(
                 ) {
                     Column {
                         Text(
-                            text = "AI-перевод",
+                            text = s.aiTranslation,
                             fontWeight = FontWeight.Medium,
                             fontSize = 15.sp
                         )
                         Text(
-                            text = "Скоро...",
+                            text = s.comingSoon,
                             color = Color.Gray,
                             fontSize = 12.sp
                         )
@@ -168,7 +159,6 @@ fun LanguageScreen(
                             .fillMaxWidth()
                             .clickable {
                                 viewModel.setLanguage(language.code)
-                                showRestartSnackbar = true
                             },
                         shape = RoundedCornerShape(10.dp),
                         tonalElevation = if (isSelected) 4.dp else 1.dp,

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/LinkedDevicesScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/LinkedDevicesScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.Check
 import kotlinx.coroutines.delay
 import androidx.compose.foundation.Image
 import io.github.alexzhirkevich.qrose.rememberQrCodePainter
+import com.example.memegram.localization.LocalStrings
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -40,6 +41,7 @@ fun LinkedDevicesScreen(
     onNavigateToScanQr: () -> Unit,
     vm: LinkedDevicesViewModel = koinViewModel()
 ) {
+    val s = LocalStrings.current
     val devices        by vm.devices.collectAsState()
     val pending        by vm.pendingAdditions.collectAsState()
     val qrPayload      by vm.qrPayload.collectAsState()
@@ -64,15 +66,15 @@ fun LinkedDevicesScreen(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
-                title = { Text("Связанные устройства") },
+                title = { Text(s.linkedDevicesTitle) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Назад")
+                        Icon(Icons.Default.ArrowBack, contentDescription = s.back)
                     }
                 },
                 actions = {
                     IconButton(onClick = { vm.load() }) {
-                        Icon(Icons.Default.Refresh, contentDescription = "Обновить")
+                        Icon(Icons.Default.Refresh, contentDescription = s.refresh)
                     }
                 }
             )
@@ -90,7 +92,7 @@ fun LinkedDevicesScreen(
             contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            // ── Добавить устройство ────────────────────────────────
+            // ── Add device ────────────────────────────────────────────
             item {
                 Button(
                     onClick = { vm.initAddDevice() },
@@ -99,15 +101,15 @@ fun LinkedDevicesScreen(
                 ) {
                     Icon(Icons.Default.QrCode, contentDescription = null)
                     Spacer(Modifier.width(8.dp))
-                    Text("Добавить устройство по QR")
+                    Text(s.addDeviceByQr)
                 }
             }
 
-            // ── Ожидающие подтверждения ───────────────────────────
+            // ── Pending confirmation ──────────────────────────────────
             if (pending.isNotEmpty()) {
                 item {
                     Text(
-                        "Ожидают подтверждения",
+                        s.pendingConfirmation,
                         style = MaterialTheme.typography.titleSmall,
                         color = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.padding(vertical = 4.dp)
@@ -116,16 +118,18 @@ fun LinkedDevicesScreen(
                 items(pending) { reg ->
                     PendingDeviceCard(
                         registration = reg,
+                        declineLabel = s.decline,
+                        allowLabel = s.allow,
                         onConfirm  = { vm.confirmAddition(reg.registrationId, true) },
                         onReject   = { vm.confirmAddition(reg.registrationId, false) }
                     )
                 }
             }
 
-            // ── Список устройств ──────────────────────────────────
+            // ── Device list ───────────────────────────────────────────
             item {
                 Text(
-                    "Мои устройства",
+                    s.myDevices,
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(vertical = 4.dp)
@@ -134,16 +138,28 @@ fun LinkedDevicesScreen(
             items(devices) { device ->
                 DeviceCard(
                     device   = device,
+                    thisDeviceLabel = s.thisDevice,
+                    revokedLabel = s.revoked,
+                    revokeLabel = s.revoke,
+                    revokeTitle = s.revokeDeviceTitle,
+                    revokeMessage = s.revokeDeviceMessage(device.name),
+                    cancelLabel = s.cancel,
                     onRevoke = { if (!device.isCurrentDevice) vm.revokeDevice(device.serverId) }
                 )
             }
         }
     }
 
-    // ── QR диалог ─────────────────────────────────────────────────
+    // ── QR dialog ─────────────────────────────────────────────────────
     qrPayload?.let { payload ->
         QrDialog(
             payload = payload,
+            addDeviceLabel = s.addDevice,
+            copyCodeHint = s.copyCodeHint,
+            copyCodeLabel = s.copyCode,
+            codeCopiedLabel = s.codeCopied,
+            scanQrInsteadLabel = s.scanQrInstead,
+            closeLabel = s.close,
             onDismiss = { vm.clearQr() },
             onNavigateToScan = {
                 vm.clearQr()
@@ -154,7 +170,16 @@ fun LinkedDevicesScreen(
 }
 
 @Composable
-private fun DeviceCard(device: DeviceUiModel, onRevoke: () -> Unit) {
+private fun DeviceCard(
+    device: DeviceUiModel,
+    thisDeviceLabel: String,
+    revokedLabel: String,
+    revokeLabel: String,
+    revokeTitle: String,
+    revokeMessage: String,
+    cancelLabel: String,
+    onRevoke: () -> Unit
+) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape    = RoundedCornerShape(12.dp),
@@ -183,7 +208,7 @@ private fun DeviceCard(device: DeviceUiModel, onRevoke: () -> Unit) {
                     Text(device.name, fontWeight = FontWeight.SemiBold)
                     if (device.isCurrentDevice) {
                         Spacer(Modifier.width(6.dp))
-                        Badge { Text("это устройство") }
+                        Badge { Text(thisDeviceLabel) }
                     }
                 }
                 Text(
@@ -193,7 +218,7 @@ private fun DeviceCard(device: DeviceUiModel, onRevoke: () -> Unit) {
                 )
                 if (!device.isActive) {
                     Text(
-                        "Отозвано",
+                        revokedLabel,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.error
                     )
@@ -204,22 +229,22 @@ private fun DeviceCard(device: DeviceUiModel, onRevoke: () -> Unit) {
                 IconButton(onClick = { showConfirm = true }) {
                     Icon(
                         Icons.Default.DeleteOutline,
-                        contentDescription = "Отозвать",
+                        contentDescription = revokeLabel,
                         tint = MaterialTheme.colorScheme.error
                     )
                 }
                 if (showConfirm) {
                     AlertDialog(
                         onDismissRequest = { showConfirm = false },
-                        title   = { Text("Отозвать устройство?") },
-                        text    = { Text("'${device.name}' будет удалено из вашего аккаунта.") },
+                        title   = { Text(revokeTitle) },
+                        text    = { Text(revokeMessage) },
                         confirmButton = {
                             TextButton(onClick = { showConfirm = false; onRevoke() }) {
-                                Text("Отозвать", color = MaterialTheme.colorScheme.error)
+                                Text(revokeLabel, color = MaterialTheme.colorScheme.error)
                             }
                         },
                         dismissButton = {
-                            TextButton(onClick = { showConfirm = false }) { Text("Отмена") }
+                            TextButton(onClick = { showConfirm = false }) { Text(cancelLabel) }
                         }
                     )
                 }
@@ -231,6 +256,8 @@ private fun DeviceCard(device: DeviceUiModel, onRevoke: () -> Unit) {
 @Composable
 private fun PendingDeviceCard(
     registration: PendingDeviceRegistration,
+    declineLabel: String,
+    allowLabel: String,
     onConfirm: () -> Unit,
     onReject: () -> Unit
 ) {
@@ -264,9 +291,9 @@ private fun PendingDeviceCard(
                     colors = ButtonDefaults.outlinedButtonColors(
                         contentColor = MaterialTheme.colorScheme.error
                     )
-                ) { Text("Отклонить") }
+                ) { Text(declineLabel) }
                 Button(onClick = onConfirm, modifier = Modifier.weight(1f)) {
-                    Text("Разрешить")
+                    Text(allowLabel)
                 }
             }
         }
@@ -274,7 +301,17 @@ private fun PendingDeviceCard(
 }
 
 @Composable
-private fun QrDialog(payload: String, onDismiss: () -> Unit, onNavigateToScan: () -> Unit) {
+private fun QrDialog(
+    payload: String,
+    addDeviceLabel: String,
+    copyCodeHint: String,
+    copyCodeLabel: String,
+    codeCopiedLabel: String,
+    scanQrInsteadLabel: String,
+    closeLabel: String,
+    onDismiss: () -> Unit,
+    onNavigateToScan: () -> Unit
+) {
     val clipboardManager = LocalClipboardManager.current
     var codeCopied by remember { mutableStateOf(false) }
 
@@ -295,12 +332,12 @@ private fun QrDialog(payload: String, onDismiss: () -> Unit, onNavigateToScan: (
                     .verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Text("Добавить устройство", style = MaterialTheme.typography.titleMedium)
+                Text(addDeviceLabel, style = MaterialTheme.typography.titleMedium)
                 Spacer(Modifier.height(16.dp))
 
                 Image(
                     painter = rememberQrCodePainter(payload),
-                    contentDescription = "QR-код для добавления устройства",
+                    contentDescription = addDeviceLabel,
                     modifier = Modifier
                         .size(220.dp)
                         .background(Color.White, RoundedCornerShape(8.dp))
@@ -313,7 +350,7 @@ private fun QrDialog(payload: String, onDismiss: () -> Unit, onNavigateToScan: (
                 Spacer(Modifier.height(12.dp))
 
                 Text(
-                    "Или скопируйте код и вставьте его на новом устройстве",
+                    copyCodeHint,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center
@@ -348,7 +385,7 @@ private fun QrDialog(payload: String, onDismiss: () -> Unit, onNavigateToScan: (
                         Icon(
                             imageVector = if (codeCopied) Icons.Default.Check
                             else Icons.Default.ContentCopy,
-                            contentDescription = "Скопировать код",
+                            contentDescription = copyCodeLabel,
                             tint = if (codeCopied) MaterialTheme.colorScheme.primary
                             else MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.size(20.dp)
@@ -358,7 +395,7 @@ private fun QrDialog(payload: String, onDismiss: () -> Unit, onNavigateToScan: (
 
                 AnimatedVisibility(visible = codeCopied) {
                     Text(
-                        "✓ Скопировано",
+                        codeCopiedLabel,
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.padding(top = 4.dp)
@@ -367,9 +404,9 @@ private fun QrDialog(payload: String, onDismiss: () -> Unit, onNavigateToScan: (
 
                 Spacer(Modifier.height(16.dp))
                 TextButton(onClick = onNavigateToScan) {
-                    Text("Хочу отсканировать QR вместо этого")
+                    Text(scanQrInsteadLabel)
                 }
-                TextButton(onClick = onDismiss) { Text("Закрыть") }
+                TextButton(onClick = onDismiss) { Text(closeLabel) }
             }
         }
     }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/NotificationsScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/NotificationsScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.memegram.localization.LocalStrings
 
 sealed class NotifItem {
     data class Category(
@@ -48,27 +48,31 @@ fun NotificationsScreen(
     onBack: () -> Unit,
     viewModel: NotificationsViewModel
 ) {
-    val currentVibrate  by viewModel.vibrate.collectAsState()
-    val currentRingtone by viewModel.ringtone.collectAsState()
-    val topBarTextColor = if (topBarColor.luminance() > 0.5f) Color.Black else Color.White
+    val s = LocalStrings.current
+    val vibrateStrength  by viewModel.vibrateStrength.collectAsState()
+    val ringtoneKey      by viewModel.ringtoneKey.collectAsState()
+    val currentVibrate   = NotificationsViewModel.strengthToLabel(vibrateStrength, s)
+    val currentRingtone  = NotificationsViewModel.ringtoneKeyToLabel(ringtoneKey, s)
+    val topBarTextColor  = if (topBarColor.luminance() > 0.5f) Color.Black else Color.White
+
     val allData = remember {
         mutableStateListOf<NotifItem>().apply {
-            add(NotifItem.Category(1, "Личные чаты"))
+            add(NotifItem.Category(1, s.privateChats))
             add(NotifItem.Chat(1, "Neko", false))
             add(NotifItem.Chat(1, "Denis", true))
             add(NotifItem.Chat(1, "Ivan Kopylov", false))
-            add(NotifItem.Category(2, "Группы"))
+            add(NotifItem.Category(2, s.groups))
             add(NotifItem.Chat(2, "Kotlin Evil", false))
-            add(NotifItem.Category(3, "Каналы"))
+            add(NotifItem.Category(3, s.channels))
             add(NotifItem.Chat(3, "Meme Channel", false))
             add(NotifItem.CallsSettings)
         }
     }
 
     var muteDialogTarget by remember { mutableStateOf<NotifItem.Chat?>(null) }
-    var muteHoursDialog by remember { mutableStateOf<NotifItem.Chat?>(null) }
-    var muteHoursInput by remember { mutableStateOf("") }
-    var showVibrateDialog by remember { mutableStateOf(false) }
+    var muteHoursDialog  by remember { mutableStateOf<NotifItem.Chat?>(null) }
+    var muteHoursInput   by remember { mutableStateOf("") }
+    var showVibrateDialog  by remember { mutableStateOf(false) }
     var showRingtoneDialog by remember { mutableStateOf(false) }
 
     val displayData = remember(allData.toList()) {
@@ -89,12 +93,14 @@ fun NotificationsScreen(
         list
     }
 
-
     muteDialogTarget?.let { chat ->
+        val enableOption  = s.enableNotifications
+        val disableForever = s.disableForever
+        val disableForTime = s.disableForTime
         val options = if (chat.isMuted)
-            listOf("Включить уведомления")
+            listOf(enableOption)
         else
-            listOf("Отключить навсегда", "Отключить на время...")
+            listOf(disableForever, disableForTime)
 
         AlertDialog(
             onDismissRequest = { muteDialogTarget = null },
@@ -124,7 +130,8 @@ fun NotificationsScreen(
                                     muteDialogTarget = null
                                 }
                                 .padding(vertical = 12.dp),
-                            color = if (option.startsWith("Отключить")) MaterialTheme.colorScheme.error
+                            color = if (option == disableForever || option == disableForTime)
+                                MaterialTheme.colorScheme.error
                             else MaterialTheme.colorScheme.primary
                         )
                         if (idx < options.lastIndex) HorizontalDivider()
@@ -133,7 +140,7 @@ fun NotificationsScreen(
             },
             confirmButton = {},
             dismissButton = {
-                TextButton(onClick = { muteDialogTarget = null }) { Text("Отмена") }
+                TextButton(onClick = { muteDialogTarget = null }) { Text(s.cancel) }
             }
         )
     }
@@ -141,12 +148,12 @@ fun NotificationsScreen(
     muteHoursDialog?.let { chat ->
         AlertDialog(
             onDismissRequest = { muteHoursDialog = null },
-            title = { Text("Отключить на сколько часов?") },
+            title = { Text(s.disableForHowLong) },
             text = {
                 OutlinedTextField(
                     value = muteHoursInput,
                     onValueChange = { muteHoursInput = it.filter { c -> c.isDigit() } },
-                    label = { Text("Часы") },
+                    label = { Text(s.hours) },
                     singleLine = true
                 )
             },
@@ -163,19 +170,19 @@ fun NotificationsScreen(
                     }
                     muteHoursInput = ""
                     muteHoursDialog = null
-                }) { Text("Отключить") }
+                }) { Text(s.disable) }
             },
             dismissButton = {
-                TextButton(onClick = { muteHoursDialog = null }) { Text("Отмена") }
+                TextButton(onClick = { muteHoursDialog = null }) { Text(s.cancel) }
             }
         )
     }
 
     if (showVibrateDialog) {
-        val options = NotificationsViewModel.vibrateOptions
+        val options = NotificationsViewModel.vibrateOptions(s)
         AlertDialog(
             onDismissRequest = { showVibrateDialog = false },
-            title = { Text("Вибрация для звонков") },
+            title = { Text(s.vibrationForCalls) },
             text = {
                 Column {
                     options.forEach { opt ->
@@ -183,7 +190,9 @@ fun NotificationsScreen(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable {
-                                    viewModel.setVibrate(opt)
+                                    viewModel.setVibrateStrength(
+                                        NotificationsViewModel.labelToStrength(opt, s)
+                                    )
                                     showVibrateDialog = false
                                 }
                                 .padding(vertical = 10.dp),
@@ -191,7 +200,12 @@ fun NotificationsScreen(
                         ) {
                             RadioButton(
                                 selected = currentVibrate == opt,
-                                onClick = { viewModel.setVibrate(opt); showVibrateDialog = false }
+                                onClick = {
+                                    viewModel.setVibrateStrength(
+                                        NotificationsViewModel.labelToStrength(opt, s)
+                                    )
+                                    showVibrateDialog = false
+                                }
                             )
                             Spacer(Modifier.width(8.dp))
                             Text(opt)
@@ -201,16 +215,16 @@ fun NotificationsScreen(
             },
             confirmButton = {},
             dismissButton = {
-                TextButton(onClick = { showVibrateDialog = false }) { Text("Отмена") }
+                TextButton(onClick = { showVibrateDialog = false }) { Text(s.cancel) }
             }
         )
     }
 
     if (showRingtoneDialog) {
-        val options = NotificationsViewModel.ringtoneOptions
+        val options = NotificationsViewModel.ringtoneOptions(s)
         AlertDialog(
             onDismissRequest = { showRingtoneDialog = false },
-            title = { Text("Мелодия звонка") },
+            title = { Text(s.ringtone) },
             text = {
                 Column {
                     options.forEach { opt ->
@@ -218,7 +232,9 @@ fun NotificationsScreen(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable {
-                                    viewModel.setRingtone(opt)
+                                    viewModel.setRingtoneKey(
+                                        NotificationsViewModel.ringtoneLabelToKey(opt, s)
+                                    )
                                     showRingtoneDialog = false
                                 }
                                 .padding(vertical = 10.dp),
@@ -226,7 +242,12 @@ fun NotificationsScreen(
                         ) {
                             RadioButton(
                                 selected = currentRingtone == opt,
-                                onClick = { viewModel.setRingtone(opt); showRingtoneDialog = false }
+                                onClick = {
+                                    viewModel.setRingtoneKey(
+                                        NotificationsViewModel.ringtoneLabelToKey(opt, s)
+                                    )
+                                    showRingtoneDialog = false
+                                }
                             )
                             Spacer(Modifier.width(8.dp))
                             Text(opt)
@@ -236,16 +257,15 @@ fun NotificationsScreen(
             },
             confirmButton = {},
             dismissButton = {
-                TextButton(onClick = { showRingtoneDialog = false }) { Text("Отмена") }
+                TextButton(onClick = { showRingtoneDialog = false }) { Text(s.cancel) }
             }
         )
     }
 
-
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Уведомления") },
+                title = { Text(s.notificationsTitle) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -301,6 +321,8 @@ fun NotificationsScreen(
                     is NotifItem.Chat -> ChatNotifItem(
                         chat = item,
                         accentColor = topBarColor,
+                        disabledLabel = s.disabled,
+                        enabledLabel = s.enabled,
                         onClick = { muteDialogTarget = item }
                     )
 
@@ -308,6 +330,9 @@ fun NotificationsScreen(
                         accentColor = topBarColor,
                         vibrate = currentVibrate,
                         ringtone = currentRingtone,
+                        callsSectionLabel = s.callsSection,
+                        vibrationLabel = s.vibration,
+                        ringtoneLabel = s.ringtone,
                         onVibrateClick = { showVibrateDialog = true },
                         onRingtoneClick = { showRingtoneDialog = true }
                     )
@@ -361,10 +386,12 @@ private fun CategoryItem(
 private fun ChatNotifItem(
     chat: NotifItem.Chat,
     accentColor: Color,
+    disabledLabel: String,
+    enabledLabel: String,
     onClick: () -> Unit
 ) {
     val indicatorColor = if (chat.isMuted) Color(0xFFFF3B30) else accentColor
-    val statusText = if (chat.isMuted) "Отключено" else "Включено"
+    val statusText = if (chat.isMuted) disabledLabel else enabledLabel
 
     Surface(
         modifier = Modifier
@@ -407,12 +434,15 @@ private fun CallsSettingsBlock(
     accentColor: Color,
     vibrate: String,
     ringtone: String,
+    callsSectionLabel: String,
+    vibrationLabel: String,
+    ringtoneLabel: String,
     onVibrateClick: () -> Unit,
     onRingtoneClick: () -> Unit
 ) {
     Column(modifier = Modifier.padding(top = 20.dp)) {
         Text(
-            text = "ЗВОНКИ",
+            text = callsSectionLabel,
             fontSize = 12.sp,
             color = Color(0xFF8E8E93),
             fontWeight = FontWeight.Bold,
@@ -432,7 +462,7 @@ private fun CallsSettingsBlock(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Text("Вибрация", fontSize = 15.sp)
+                    Text(vibrationLabel, fontSize = 15.sp)
                     Text(
                         text = vibrate,
                         color = accentColor,
@@ -450,7 +480,7 @@ private fun CallsSettingsBlock(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Text("Мелодия звонка", fontSize = 15.sp)
+                    Text(ringtoneLabel, fontSize = 15.sp)
                     Text(
                         text = ringtone,
                         color = accentColor,

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/NotificationsViewModel.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/NotificationsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.memegram.data.models.UpdateSettingsRequest
 import com.example.memegram.data.repository.UserRepository
+import com.example.memegram.localization.AppStrings
 import com.russhwolf.settings.Settings
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,50 +16,68 @@ class NotificationsViewModel(
     private val userRepository: UserRepository
 ) : ViewModel() {
 
-    private val _vibrate  = MutableStateFlow(settings.getString("notif_vibrate",  "Средняя"))
-    val vibrate:  StateFlow<String> = _vibrate.asStateFlow()
-    private val _ringtone = MutableStateFlow(settings.getString("notif_ringtone", "Default"))
-    val ringtone: StateFlow<String> = _ringtone.asStateFlow()
+    private val _vibrateStrength = MutableStateFlow(settings.getInt("notif_vibrate_strength", 2))
+    val vibrateStrength: StateFlow<Int> = _vibrateStrength.asStateFlow()
+
+    private val _ringtoneKey = MutableStateFlow(settings.getString("notif_ringtone_key", "default"))
+    val ringtoneKey: StateFlow<String> = _ringtoneKey.asStateFlow()
 
     init {
         viewModelScope.launch {
             userRepository.loadSettings().onSuccess { s ->
-                val label = strengthToLabel(s.notificationVibrationStrength ?: 2)
-                _vibrate.value = label
-                settings.putString("notif_vibrate", label)
+                val strength = s.notificationVibrationStrength ?: 2
+                _vibrateStrength.value = strength
+                settings.putInt("notif_vibrate_strength", strength)
             }
         }
     }
 
-    fun setVibrate(label: String) {
-        _vibrate.value = label
-        settings.putString("notif_vibrate", label)
+    fun setVibrateStrength(strength: Int) {
+        _vibrateStrength.value = strength
+        settings.putInt("notif_vibrate_strength", strength)
         viewModelScope.launch {
             userRepository.updateSettings(
-                UpdateSettingsRequest(notificationVibrationStrength = labelToStrength(label))
+                UpdateSettingsRequest(notificationVibrationStrength = strength)
             )
         }
     }
 
-    fun setRingtone(label: String) {
-        _ringtone.value = label
-        settings.putString("notif_ringtone", label)
+    fun setRingtoneKey(key: String) {
+        _ringtoneKey.value = key
+        settings.putString("notif_ringtone_key", key)
     }
 
     companion object {
-        fun strengthToLabel(v: Int) = when (v) {
-            0    -> "Нет"
-            1    -> "Слабая"
-            3    -> "Сильная"
-            else -> "Средняя"
+        val ringtoneKeys = listOf("default", "classic", "simple", "none")
+
+        fun strengthToLabel(v: Int, s: AppStrings) = when (v) {
+            0    -> s.vibrateNone
+            1    -> s.vibrateWeak
+            3    -> s.vibrateStrong
+            else -> s.vibrateMedium
         }
-        fun labelToStrength(label: String) = when (label) {
-            "Нет"     -> 0
-            "Слабая"  -> 1
-            "Сильная" -> 3
-            else      -> 2
+        fun labelToStrength(label: String, s: AppStrings) = when (label) {
+            s.vibrateNone   -> 0
+            s.vibrateWeak   -> 1
+            s.vibrateStrong -> 3
+            else            -> 2
         }
-        val vibrateOptions  = listOf("Нет", "Слабая", "Средняя", "Сильная")
-        val ringtoneOptions = listOf("Default", "Классический", "Простой", "Нет")
+        fun vibrateOptions(s: AppStrings) =
+            listOf(s.vibrateNone, s.vibrateWeak, s.vibrateMedium, s.vibrateStrong)
+
+        fun ringtoneKeyToLabel(key: String, s: AppStrings) = when (key) {
+            "classic" -> s.ringtoneClassic
+            "simple"  -> s.ringtoneSimple
+            "none"    -> s.ringtoneNone
+            else      -> s.ringtoneDefault
+        }
+        fun ringtoneLabelToKey(label: String, s: AppStrings) = when (label) {
+            s.ringtoneClassic -> "classic"
+            s.ringtoneSimple  -> "simple"
+            s.ringtoneNone    -> "none"
+            else              -> "default"
+        }
+        fun ringtoneOptions(s: AppStrings) =
+            ringtoneKeys.map { ringtoneKeyToLabel(it, s) }
     }
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/PrivacyScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/PrivacyScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.memegram.localization.LocalStrings
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -27,6 +28,7 @@ fun PrivacyScreen(
     onAccountDeleted: () -> Unit,
     viewModel: PrivacyViewModel
 ) {
+    val s = LocalStrings.current
     val topBarTextColor       = if (topBarColor.luminance() < 0.5f) Color.White else Color.Black
     val profileVisibleTo      by viewModel.profileVisibleTo.collectAsState()
     val lastActiveVisibleTo   by viewModel.lastActiveVisibleTo.collectAsState()
@@ -47,65 +49,69 @@ fun PrivacyScreen(
     error?.let { msg ->
         AlertDialog(
             onDismissRequest = viewModel::clearError,
-            title = { Text("Ошибка") },
+            title = { Text(s.error) },
             text  = { Text(msg) },
-            confirmButton = { TextButton(onClick = viewModel::clearError) { Text("OK") } }
+            confirmButton = { TextButton(onClick = viewModel::clearError) { Text(s.ok) } }
         )
     }
 
     if (showProfileVisDialog) {
         PrivacyChoiceDialog(
-            title   = "Кто видит мой профиль",
-            options = PrivacyViewModel.visibilityOptions,
-            current = PrivacyViewModel.visibilityLabel(profileVisibleTo),
-            onSelect  = { viewModel.setProfileVisibleTo(PrivacyViewModel.visibilityValue(it)); showProfileVisDialog = false },
-            onDismiss = { showProfileVisDialog = false }
+            title   = s.whoSeesProfile,
+            options = PrivacyViewModel.visibilityOptions(s),
+            current = PrivacyViewModel.visibilityLabel(profileVisibleTo, s),
+            onSelect  = { viewModel.setProfileVisibleTo(PrivacyViewModel.visibilityValue(it, s)); showProfileVisDialog = false },
+            onDismiss = { showProfileVisDialog = false },
+            cancelLabel = s.cancel
         )
     }
 
     if (showLastActiveVisDialog) {
         PrivacyChoiceDialog(
-            title   = "Кто видит время активности",
-            options = PrivacyViewModel.visibilityOptions,
-            current = PrivacyViewModel.visibilityLabel(lastActiveVisibleTo),
-            onSelect  = { viewModel.setLastActiveVisibleTo(PrivacyViewModel.visibilityValue(it)); showLastActiveVisDialog = false },
-            onDismiss = { showLastActiveVisDialog = false }
+            title   = s.whoSeesLastSeen,
+            options = PrivacyViewModel.visibilityOptions(s),
+            current = PrivacyViewModel.visibilityLabel(lastActiveVisibleTo, s),
+            onSelect  = { viewModel.setLastActiveVisibleTo(PrivacyViewModel.visibilityValue(it, s)); showLastActiveVisDialog = false },
+            onDismiss = { showLastActiveVisDialog = false },
+            cancelLabel = s.cancel
         )
     }
 
     if (showAutoDeleteAccDialog) {
         PrivacyChoiceDialog(
-            title   = "Удалить аккаунт через",
-            options = PrivacyViewModel.autoDeleteOptions,
-            current = PrivacyViewModel.daysLabel(autoDeleteDays),
-            onSelect  = { viewModel.setAutoDeleteDays(PrivacyViewModel.daysValue(it)); showAutoDeleteAccDialog = false },
-            onDismiss = { showAutoDeleteAccDialog = false }
+            title   = s.deleteAccountAfter,
+            options = PrivacyViewModel.autoDeleteOptions(s),
+            current = PrivacyViewModel.daysLabel(autoDeleteDays, s),
+            onSelect  = { viewModel.setAutoDeleteDays(PrivacyViewModel.daysValue(it, s)); showAutoDeleteAccDialog = false },
+            onDismiss = { showAutoDeleteAccDialog = false },
+            cancelLabel = s.cancel
         )
     }
 
     if (showAutoDeleteMsgDialog) {
         PrivacyChoiceDialog(
-            title   = "Авто-удаление сообщений",
-            options = listOf("Выкл", "1 день", "1 неделя", "1 месяц"),
-            current = autoDeleteMsgOption ?: "Выкл",
+            title   = s.autoDeleteMessages,
+            options = listOf(s.autoDeleteOff, s.autoDelete1Day, s.autoDelete1Week, s.autoDelete1Month),
+            current = autoDeleteMsgOption ?: s.autoDeleteOff,
             onSelect  = { autoDeleteMsgOption = it; showAutoDeleteMsgDialog = false },
-            onDismiss = { showAutoDeleteMsgDialog = false }
+            onDismiss = { showAutoDeleteMsgDialog = false },
+            cancelLabel = s.cancel
         )
     }
 
     if (showDeleteAccountDialog) {
         AlertDialog(
             onDismissRequest = { showDeleteAccountDialog = false },
-            title = { Text("Удалить аккаунт?") },
-            text  = { Text("Это действие необратимо. Все данные будут удалены.") },
+            title = { Text(s.deleteAccountTitle) },
+            text  = { Text(s.deleteAccountWarning) },
             confirmButton = {
                 TextButton(
                     onClick = { showDeleteAccountDialog = false; viewModel.deleteAccount() },
                     colors  = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
-                ) { Text("Удалить") }
+                ) { Text(s.delete) }
             },
             dismissButton = {
-                TextButton(onClick = { showDeleteAccountDialog = false }) { Text("Отмена") }
+                TextButton(onClick = { showDeleteAccountDialog = false }) { Text(s.cancel) }
             }
         )
     }
@@ -113,7 +119,7 @@ fun PrivacyScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Конфиденциальность") },
+                title = { Text(s.privacyTitle) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = topBarTextColor)
@@ -135,42 +141,42 @@ fun PrivacyScreen(
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            SectionLabel("Контакты")
+            SectionLabel(s.contactsTitle)
             PrivacyItem(
-                title = "Чёрный список",
-                subtitle = "Управление",
+                title = s.blackList,
+                subtitle = s.manage,
                 accentColor = topBarColor, showArrow = true,
                 onClick = onBlackListClick
             )
 
             Spacer(Modifier.height(4.dp))
 
-            SectionLabel("Приватность")
+            SectionLabel(s.privacySection)
             PrivacyItem(
-                title = "Кто видит мой профиль",
-                subtitle = PrivacyViewModel.visibilityLabel(profileVisibleTo),
+                title = s.whoSeesProfile,
+                subtitle = PrivacyViewModel.visibilityLabel(profileVisibleTo, s),
                 accentColor = topBarColor, showArrow = true,
                 onClick = { showProfileVisDialog = true }
             )
             PrivacyItem(
-                title = "Кто видит время активности",
-                subtitle = PrivacyViewModel.visibilityLabel(lastActiveVisibleTo),
+                title = s.whoSeesLastSeen,
+                subtitle = PrivacyViewModel.visibilityLabel(lastActiveVisibleTo, s),
                 accentColor = topBarColor, showArrow = true,
                 onClick = { showLastActiveVisDialog = true }
             )
 
             Spacer(Modifier.height(4.dp))
 
-            SectionLabel("Авто-удаление")
+            SectionLabel(s.autoDeleteSection)
             PrivacyItem(
-                title = "Авто-удаление сообщений",
-                subtitle = autoDeleteMsgOption ?: "Выкл",
+                title = s.autoDeleteMessages,
+                subtitle = autoDeleteMsgOption ?: s.autoDeleteOff,
                 accentColor = topBarColor, showArrow = true,
                 onClick = { showAutoDeleteMsgDialog = true }
             )
             PrivacyItem(
-                title = "Удалить аккаунт через",
-                subtitle = PrivacyViewModel.daysLabel(autoDeleteDays),
+                title = s.deleteAccountAfter,
+                subtitle = PrivacyViewModel.daysLabel(autoDeleteDays, s),
                 accentColor = topBarColor, showArrow = true,
                 onClick = { showAutoDeleteAccDialog = true }
             )
@@ -194,7 +200,7 @@ fun PrivacyScreen(
                         CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
                     } else {
                         Text(
-                            "Удалить аккаунт",
+                            s.deleteAccountAction,
                             color = MaterialTheme.colorScheme.error,
                             fontWeight = FontWeight.Medium,
                             fontSize = 15.sp
@@ -212,7 +218,8 @@ private fun PrivacyChoiceDialog(
     options: List<String>,
     current: String,
     onSelect: (String) -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    cancelLabel: String
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -235,7 +242,7 @@ private fun PrivacyChoiceDialog(
             }
         },
         confirmButton = {},
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Отмена") } }
+        dismissButton = { TextButton(onClick = onDismiss) { Text(cancelLabel) } }
     )
 }
 

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/PrivacyViewModel.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/PrivacyViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.memegram.data.local.SessionManager
 import com.example.memegram.data.models.UpdateSettingsRequest
 import com.example.memegram.data.repository.UserRepository
+import com.example.memegram.localization.AppStrings
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
@@ -82,32 +83,33 @@ class PrivacyViewModel(
     fun clearError() { _error.value = null }
 
     companion object {
-        fun visibilityLabel(value: String) = when (value) {
-            "contacts" -> "Контакты"
-            "nobody"   -> "Никто"
-            else       -> "Все"
+        fun visibilityLabel(value: String, s: AppStrings) = when (value) {
+            "contacts" -> s.visContacts
+            "nobody"   -> s.visNobody
+            else       -> s.visEverybody
         }
-        fun visibilityValue(label: String) = when (label) {
-            "Контакты" -> "contacts"
-            "Никто"    -> "nobody"
-            else       -> "everybody"
+        fun visibilityValue(label: String, s: AppStrings) = when (label) {
+            s.visContacts -> "contacts"
+            s.visNobody   -> "nobody"
+            else          -> "everybody"
         }
-        val visibilityOptions = listOf("Все", "Контакты", "Никто")
+        fun visibilityOptions(s: AppStrings) = listOf(s.visEverybody, s.visContacts, s.visNobody)
 
-        fun daysLabel(days: Int?) = when (days) {
-            30  -> "1 месяц"
-            90  -> "3 месяца"
-            180 -> "6 месяцев"
-            365 -> "1 год"
-            else -> "Выкл"
+        fun daysLabel(days: Int?, s: AppStrings) = when (days) {
+            30  -> s.days1Month
+            90  -> s.days3Months
+            180 -> s.days6Months
+            365 -> s.days1Year
+            else -> s.daysOff
         }
-        fun daysValue(label: String) = when (label) {
-            "1 месяц"  -> 30
-            "3 месяца" -> 90
-            "6 месяцев"-> 180
-            "1 год"    -> 365
-            else       -> null
+        fun daysValue(label: String, s: AppStrings) = when (label) {
+            s.days1Month  -> 30
+            s.days3Months -> 90
+            s.days6Months -> 180
+            s.days1Year   -> 365
+            else          -> null
         }
-        val autoDeleteOptions = listOf("Выкл", "1 месяц", "3 месяца", "6 месяцев", "1 год")
+        fun autoDeleteOptions(s: AppStrings) =
+            listOf(s.daysOff, s.days1Month, s.days3Months, s.days6Months, s.days1Year)
     }
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ProfileScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ProfileScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.memegram.localization.LocalStrings
 import io.github.vinceglb.filekit.compose.rememberFilePickerLauncher
 import io.github.vinceglb.filekit.core.PickerMode
 import io.github.vinceglb.filekit.core.PickerType
@@ -42,6 +43,7 @@ fun ProfileScreen(
     viewModel: ProfileViewModel
 ) {
     val topBarTextColor = if (topBarColor.luminance() < 0.5f) Color.White else Color.Black
+    val s = LocalStrings.current
     val username      by viewModel.username.collectAsState()
     val bio           by viewModel.bio.collectAsState()
     val isLoading     by viewModel.isLoading.collectAsState()
@@ -68,16 +70,16 @@ fun ProfileScreen(
     error?.let { msg ->
         AlertDialog(
             onDismissRequest = viewModel::clearError,
-            title = { Text("Ошибка") },
+            title = { Text(s.error) },
             text  = { Text(msg) },
-            confirmButton = { TextButton(onClick = viewModel::clearError) { Text("OK") } }
+            confirmButton = { TextButton(onClick = viewModel::clearError) { Text(s.ok) } }
         )
     }
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Профиль") },
+                title = { Text(s.profileTitle) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = topBarTextColor)
@@ -190,7 +192,7 @@ fun ProfileScreen(
                 OutlinedTextField(
                     value = usernameInput,
                     onValueChange = { usernameInput = it },
-                    label = { Text("Имя пользователя") },
+                    label = { Text(s.username) },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(12.dp),
@@ -199,7 +201,7 @@ fun ProfileScreen(
                             TextButton(
                                 onClick = { viewModel.updateProfile(newUsername = usernameInput, newBio = bioInput) },
                                 enabled = !isLoading
-                            ) { Text("Сохранить") }
+                            ) { Text(s.save) }
                         }
                     }
                 )
@@ -207,7 +209,7 @@ fun ProfileScreen(
                 OutlinedTextField(
                     value = bioInput,
                     onValueChange = { bioInput = it },
-                    label = { Text("О себе") },
+                    label = { Text(s.aboutMe) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(min = 90.dp),
@@ -218,7 +220,7 @@ fun ProfileScreen(
                             TextButton(
                                 onClick = { viewModel.updateProfile(newUsername = usernameInput, newBio = bioInput) },
                                 enabled = !isLoading
-                            ) { Text("Сохранить") }
+                            ) { Text(s.save) }
                         }
                     }
                 )
@@ -238,7 +240,7 @@ fun ProfileScreen(
                             modifier = Modifier.size(16.dp)
                         )
                         Spacer(Modifier.width(8.dp))
-                        Text(if (keyCopied) "Скопировано!" else "Скопировать мой публичный ключ")
+                        Text(if (keyCopied) s.copied else s.copyMyPublicKey)
                     }
                 }
 
@@ -254,7 +256,7 @@ fun ProfileScreen(
                 ) {
                     Icon(Icons.Default.ExitToApp, contentDescription = null, modifier = Modifier.size(18.dp))
                     Spacer(Modifier.width(8.dp))
-                    Text("Выйти из аккаунта")
+                    Text(s.logout)
                 }
 
                 if (isLoading) {

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/StorageScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/StorageScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.example.memegram.localization.LocalStrings
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -28,6 +29,7 @@ fun StorageScreen(
     onBack: () -> Unit,
     viewModel: StorageViewModel
 ) {
+    val s = LocalStrings.current
     val topBarTextColor = if (topBarColor.luminance() < 0.5f) Color.White else Color.Black
     val cleanupStrategy by viewModel.cleanupStrategy.collectAsState()
 
@@ -40,7 +42,7 @@ fun StorageScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Данные и память") },
+                title = { Text(s.dataAndStorageTitle) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = topBarTextColor)
@@ -61,24 +63,24 @@ fun StorageScreen(
                 .verticalScroll(rememberScrollState())
         ) {
             Text(
-                "Автоматическая очистка кэша",
+                s.autoClearCache,
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(16.dp)
             )
 
             val options = listOf(
-                "TTL" to "Удалять старые по времени (1 месяц)",
-                "LRU" to "Удалять наименее недавно использованные",
-                "LFU" to "Удалять реже всего запрашиваемые",
-                "FIFO" to "Удалять самые старые (FIFO)"
+                "TTL"  to s.deleteOldByTime,
+                "LRU"  to s.deleteLeastRecent,
+                "LFU"  to s.deleteLeastRequested,
+                "FIFO" to s.deleteOldestFifo
             )
 
             AnimatedVisibility(visible = true) {
                 when (selectedStrategy) {
                     "FIFO" -> StrategyParamSlider(
-                        label       = "Сообщений в чате (последних)",
-                        description = "Старые сообщения сверх лимита будут удалены из этого чата",
+                        label       = s.messagesInChat,
+                        description = s.fifoDescription,
                         value       = fifoLimit,
                         min         = 100L,
                         max         = 10_000L,
@@ -86,8 +88,8 @@ fun StorageScreen(
                         onChanged   = viewModel::updateFifoLimit
                     )
                     "TTL"  -> StrategyParamSlider(
-                        label       = "Хранить сообщения (дней)",
-                        description = "Сообщения старше указанного периода удаляются автоматически",
+                        label       = s.storeMessagesDays,
+                        description = s.ttlDescription,
                         value       = ttlDays,
                         min         = 1L,
                         max         = 365L,
@@ -95,8 +97,8 @@ fun StorageScreen(
                         onChanged   = viewModel::updateTtlDays
                     )
                     "LRU"  -> StrategyParamSlider(
-                        label       = "Глобальный лимит (сообщений)",
-                        description = "Удаляются сообщения из чатов, которые давно не открывались",
+                        label       = s.globalLimit,
+                        description = s.lruDescription,
                         value       = lruLimit,
                         min         = 500L,
                         max         = 50_000L,
@@ -104,8 +106,8 @@ fun StorageScreen(
                         onChanged   = viewModel::updateLruLimit
                     )
                     "LFU"  -> StrategyParamSlider(
-                        label       = "Глобальный лимит (сообщений)",
-                        description = "Удаляются сообщения из чатов, в которые реже всего заходят",
+                        label       = s.globalLimit,
+                        description = s.lfuDescription,
                         value       = lfuLimit,
                         min         = 500L,
                         max         = 50_000L,
@@ -146,7 +148,7 @@ fun StorageScreen(
             ) {
                 Icon(Icons.Default.DeleteOutline, contentDescription = null, modifier = Modifier.size(18.dp))
                 Spacer(Modifier.width(8.dp))
-                Text("Очистить локальный кэш сейчас")
+                Text(s.clearLocalCache)
             }
         }
     }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/UserProfileScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/UserProfileScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.memegram.localization.LocalStrings
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -29,6 +30,7 @@ fun UserProfileScreen(
     viewModel: UserProfileViewModel
 ) {
     val topBarTextColor = if (topBarColor.luminance() > 0.5f) Color.Black else Color.White
+    val s = LocalStrings.current
     val profile by viewModel.userProfile.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
     val message by viewModel.actionMessage.collectAsState()
@@ -46,7 +48,7 @@ fun UserProfileScreen(
     }
 
     val displayUsername = profile?.username ?: initialUsername
-    val displayBio = profile?.bio ?: "Загрузка..."
+    val displayBio = profile?.bio ?: s.loading
 
     Scaffold(
         topBar = {
@@ -99,7 +101,7 @@ fun UserProfileScreen(
                         Icon(Icons.AutoMirrored.Filled.Message, null)
                     }
                     Spacer(Modifier.height(8.dp))
-                    Text("Написать", style = MaterialTheme.typography.bodySmall)
+                    Text(s.sendMessage, style = MaterialTheme.typography.bodySmall)
                 }
 
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -110,7 +112,7 @@ fun UserProfileScreen(
                         Icon(Icons.Default.PersonAdd, null)
                     }
                     Spacer(Modifier.height(8.dp))
-                    Text("В контакты", style = MaterialTheme.typography.bodySmall)
+                    Text(s.addToContactsButton, style = MaterialTheme.typography.bodySmall)
                 }
             }
         }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/audio/AudioInterfaces.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/audio/AudioInterfaces.kt
@@ -22,6 +22,8 @@ interface AudioPlayer {
     fun isPlaying(): Boolean
     fun isPaused(): Boolean
     fun getProgress(): Float
+    fun getDurationMs(): Long
+    fun seekTo(fraction: Float)
 }
 
 expect fun createAudioRecorder(): AudioRecorder

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/audio/GlobalAudioPlayer.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/audio/GlobalAudioPlayer.kt
@@ -1,0 +1,110 @@
+package com.example.memegram.audio
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class GlobalAudioPlayer {
+
+    // ── public state ──────────────────────────────────────────────────────
+    data class State(
+        val status: PlaybackStatus = PlaybackStatus.IDLE,
+        val mediaId: String? = null,
+        val chatName: String = "",
+        val progress: Float = 0f,
+        val durationMs: Long = 0L,
+        val waveform: List<Int> = emptyList()
+    )
+
+    enum class PlaybackStatus { IDLE, PLAYING, PAUSED }
+
+    private val _state = MutableStateFlow(State())
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    // ── internals ─────────────────────────────────────────────────────────
+    private val player: AudioPlayer = createAudioPlayer()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private var progressJob: Job? = null
+
+    // ── public API ────────────────────────────────────────────────────────
+
+    fun play(
+        bytes: ByteArray,
+        mediaId: String,
+        chatName: String,
+        durationMs: Long,
+        waveform: List<Int>
+    ) {
+        stopInternal(notifyIdle = false)
+
+        _state.value = State(
+            status = PlaybackStatus.PLAYING,
+            mediaId = mediaId,
+            chatName = chatName,
+            progress = 0f,
+            durationMs = durationMs,
+            waveform = waveform
+        )
+
+        player.play(bytes) {
+            stopInternal(notifyIdle = true)
+        }
+        startProgressPolling()
+    }
+
+    fun pause() {
+        if (_state.value.status != PlaybackStatus.PLAYING) return
+        player.pause()
+        progressJob?.cancel()
+        _state.value = _state.value.copy(status = PlaybackStatus.PAUSED)
+    }
+
+    fun resume() {
+        if (_state.value.status != PlaybackStatus.PAUSED) return
+        player.resume()
+        _state.value = _state.value.copy(status = PlaybackStatus.PLAYING)
+        startProgressPolling()
+    }
+
+    fun togglePlayPause() {
+        when (_state.value.status) {
+            PlaybackStatus.PLAYING -> pause()
+            PlaybackStatus.PAUSED -> resume()
+            PlaybackStatus.IDLE -> { /* nothing to toggle */ }
+        }
+    }
+
+    fun seekTo(fraction: Float) {
+        if (_state.value.status == PlaybackStatus.IDLE) return
+        player.seekTo(fraction)
+        _state.value = _state.value.copy(progress = fraction.coerceIn(0f, 1f))
+    }
+
+    fun stop() = stopInternal(notifyIdle = true)
+
+    fun isActive(mediaId: String?): Boolean =
+        mediaId != null && _state.value.mediaId == mediaId && _state.value.status != PlaybackStatus.IDLE
+
+    // ── private helpers ───────────────────────────────────────────────────
+
+    private fun stopInternal(notifyIdle: Boolean) {
+        progressJob?.cancel()
+        player.stop()
+        if (notifyIdle) {
+            _state.value = State()
+        }
+    }
+
+    private fun startProgressPolling() {
+        progressJob?.cancel()
+        progressJob = scope.launch {
+            while (isActive && _state.value.status == PlaybackStatus.PLAYING) {
+                delay(50)
+                if (_state.value.status == PlaybackStatus.PLAYING) {
+                    _state.value = _state.value.copy(progress = player.getProgress())
+                }
+            }
+        }
+    }
+}

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/audio/VoicePlaybackBar.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/audio/VoicePlaybackBar.kt
@@ -1,0 +1,181 @@
+package com.example.memegram.audio
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun VoicePlaybackBar(
+    state: GlobalAudioPlayer.State,
+    onTogglePlayPause: () -> Unit,
+    onSeek: (Float) -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+    accentColor: Color = MaterialTheme.colorScheme.primary
+) {
+    val isVisible = state.status != GlobalAudioPlayer.PlaybackStatus.IDLE
+
+    AnimatedVisibility(
+        visible = isVisible,
+        enter = expandVertically() + fadeIn(),
+        exit = shrinkVertically() + fadeOut()
+    ) {
+        val isPlaying = state.status == GlobalAudioPlayer.PlaybackStatus.PLAYING
+        val playedColor = accentColor
+        val unplayedColor = accentColor.copy(alpha = 0.25f)
+        val textColor = MaterialTheme.colorScheme.onSurface
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .padding(horizontal = 8.dp, vertical = 6.dp)
+        ) {
+            // ── play / pause ──
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(accentColor.copy(alpha = 0.15f))
+                    .clickable { onTogglePlayPause() },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                    contentDescription = if (isPlaying) "Pause" else "Play",
+                    tint = accentColor,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+
+            Spacer(Modifier.width(8.dp))
+
+            // ── waveform (scrubbable) ──
+            val amplitudes = state.waveform.ifEmpty { List(30) { 1 } }
+
+            Box(modifier = Modifier.weight(1f).height(28.dp)) {
+                ScrubbableWaveform(
+                    amplitudes = amplitudes,
+                    progress = state.progress,
+                    playedColor = playedColor,
+                    unplayedColor = unplayedColor,
+                    onSeek = onSeek,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+
+            Spacer(Modifier.width(8.dp))
+
+            // ── time label ──
+            val currentMs = (state.durationMs * state.progress).toLong()
+            val timeText = "${formatMs(currentMs)} / ${formatMs(state.durationMs)}"
+            Text(
+                text = timeText,
+                color = textColor.copy(alpha = 0.7f),
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Medium
+            )
+
+            Spacer(Modifier.width(8.dp))
+
+            // ── close button ──
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .clip(CircleShape)
+                    .clickable { onClose() },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Close",
+                    tint = textColor.copy(alpha = 0.6f),
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun ScrubbableWaveform(
+    amplitudes: List<Int>,
+    progress: Float,
+    playedColor: Color,
+    unplayedColor: Color,
+    onSeek: (Float) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Canvas(
+        modifier = modifier
+            .pointerInput(Unit) {
+                detectTapGestures { offset ->
+                    onSeek((offset.x / size.width).coerceIn(0f, 1f))
+                }
+            }
+            .pointerInput(Unit) {
+                detectHorizontalDragGestures { change, _ ->
+                    change.consume()
+                    onSeek((change.position.x / size.width).coerceIn(0f, 1f))
+                }
+            }
+    ) {
+        val barWidth = 3.dp.toPx()
+        val spacing = 2.dp.toPx()
+        val maxBars = (size.width / (barWidth + spacing)).toInt()
+
+        val displayAmps = if (amplitudes.size > maxBars) amplitudes.takeLast(maxBars) else amplitudes
+
+        displayAmps.forEachIndexed { index, amp ->
+            val barHeight = maxOf(4.dp.toPx(), (amp / 9f) * size.height)
+            val x = index * (barWidth + spacing)
+            val isPlayed = (index.toFloat() / displayAmps.size) <= progress
+
+            drawRoundRect(
+                color = if (isPlayed) playedColor else unplayedColor,
+                topLeft = Offset(x, (size.height - barHeight) / 2f),
+                size = Size(barWidth, barHeight),
+                cornerRadius = CornerRadius(barWidth / 2, barWidth / 2)
+            )
+        }
+    }
+}
+
+private fun formatMs(ms: Long): String {
+    val totalSec = (ms / 1000).toInt()
+    val min = totalSec / 60
+    val sec = totalSec % 60
+    return "$min:${sec.toString().padStart(2, '0')}"
+}

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/data/local/SessionManager.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/data/local/SessionManager.kt
@@ -43,7 +43,7 @@ class SessionManager(private val settings: Settings) {
     }
 
     fun getUsername(): String {
-        return settings.getString("profile_username", "Влад")
+        return settings.getString("profile_username", "")
     }
 
     fun getBio(): String {

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/data/models/ApiModels.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/data/models/ApiModels.kt
@@ -147,7 +147,10 @@ data class SseEventData(
     @SerialName("mls_ciphertext") val mlsCiphertextB64: String? = null,
     @SerialName("new_mls_ciphertext") val newMlsCiphertextB64: String? = null,
     @SerialName("created_at") val createdAt: Long = 0L,
-    @SerialName("user_id") val userId: String? = null
+    @SerialName("user_id") val userId: String? = null,
+    @SerialName("kicked_by") val kickedBy: String? = null,
+    @SerialName("new_role") val newRole: String? = null,
+    @SerialName("reply_to_message_id") val replyToMessageId: String? = null
 )
 
 @Serializable
@@ -295,4 +298,24 @@ data class CreateGroupConversationRequest(
 @Serializable
 data class LeaveConversationRequest(
     @SerialName("commit_data") val commitData: String = ""
+)
+
+@Serializable
+data class UpdateMemberRoleRequest(
+    @SerialName("new_role") val newRole: String
+)
+
+@Serializable
+data class SuccessResponse(
+    val success: Boolean
+)
+
+@Serializable
+data class DeleteMessageRequest(
+    @SerialName("delete_for_everyone") val deleteForEveryone: Boolean = true
+)
+
+@Serializable
+data class DeleteMessageResponse(
+    val success: Boolean
 )

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/data/network/ApiService.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/data/network/ApiService.kt
@@ -218,6 +218,13 @@ class ApiService(
         }
     }
 
+    suspend fun deleteMessage(messageId: String, deleteForEveryone: Boolean = true): DeleteMessageResponse =
+        client.delete("$baseUrl/api/v1/messaging/messages/$messageId") {
+            bearerAuth(token())
+            contentType(ContentType.Application.Json)
+            setBody(DeleteMessageRequest(deleteForEveryone))
+        }.body()
+
     suspend fun getPendingWelcomes(): List<WelcomeResponse> =
         client.get("$baseUrl/api/v1/messaging/welcomes") {
             bearerAuth(token())
@@ -378,6 +385,28 @@ class ApiService(
             contentType(ContentType.Application.Json)
             setBody(request)
         }
+    }
+
+    suspend fun kickMember(conversationId: String, targetUserId: String): SuccessResponse {
+        val response = client.post("$baseUrl/api/v1/messaging/conversations/$conversationId/members/$targetUserId/kick") {
+            bearerAuth(token())
+        }
+        if (!response.status.isSuccess()) {
+            throw Exception("kickMember failed ${response.status.value}: ${response.bodyAsText()}")
+        }
+        return response.body()
+    }
+
+    suspend fun updateMemberRole(conversationId: String, targetUserId: String, newRole: String): SuccessResponse {
+        val response = client.patch("$baseUrl/api/v1/messaging/conversations/$conversationId/members/$targetUserId/role") {
+            bearerAuth(token())
+            contentType(ContentType.Application.Json)
+            setBody(UpdateMemberRoleRequest(newRole = newRole))
+        }
+        if (!response.status.isSuccess()) {
+            throw Exception("updateMemberRole failed ${response.status.value}: ${response.bodyAsText()}")
+        }
+        return response.body()
     }
 
 // ── Media ─────────────────────────────────────────────────────────────────

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/di/AppModule.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/di/AppModule.kt
@@ -15,6 +15,7 @@ import com.example.memegram.data.repository.ContactsRepositoryImpl
 import com.example.memegram.data.repository.UserRepository
 import com.example.memegram.data.repository.UserRepositoryImpl
 import com.example.memegram.database.AppDatabase
+import com.example.memegram.audio.GlobalAudioPlayer
 import com.example.memegram.mls.MlsManager
 import com.russhwolf.settings.Settings
 import org.koin.core.module.dsl.viewModelOf
@@ -40,6 +41,7 @@ val appModule = module {
     single<SqlDriver> { createDatabaseDriver() }
     single { AppDatabase(get()) }
     single<ChatRepository> { ChatRepositoryImpl(get(), get()) }
+    single { GlobalAudioPlayer() }
 
     viewModelOf(::AuthViewModel)
     viewModelOf(::ChatsViewModel)

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/localization/AppStrings.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/localization/AppStrings.kt
@@ -1,0 +1,943 @@
+package com.example.memegram.localization
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * All user-facing strings in the app.
+ * Two implementations: [RuStrings] and [EnStrings].
+ *
+ * - In @Composable functions use `val s = LocalStrings.current`
+ * - In ViewModels / plain Kotlin use `S.current`
+ */
+interface AppStrings {
+
+    // ── Common ────────────────────────────────────────────────────────
+    val cancel: String
+    val error: String
+    val delete: String
+    val add: String
+    val save: String
+    val back: String
+    val close: String
+    val search: String
+    val loading: String
+    val copied: String
+    val ok: String
+
+    // ── Auth ──────────────────────────────────────────────────────────
+    val nickname: String
+    val inviteCode: String
+    val autoLoginHint: String
+    val login: String
+    val register: String
+    val noAccountRegister: String
+    val hasAccountLogin: String
+    val loginFromOtherDevice: String
+
+    // ── Settings menu (drawer) ───────────────────────────────────────
+    val settingsAppearance: String
+    val settingsNotifications: String
+    val settingsPrivacy: String
+    val settingsDataAndStorage: String
+    val settingsContacts: String
+    val settingsLinkedDevices: String
+    val settingsLanguage: String
+
+    // ── Chats list ───────────────────────────────────────────────────
+    val searchPlaceholder: String
+    val createGroup: String
+    val addByKey: String
+    val addByQr: String
+    val createChannel: String
+    val newChat: String
+    val enterPublicKeyToChat: String
+    val publicKey: String
+    val start: String
+    val nothingFound: String
+    val youPrefix: String
+
+    // ── Chat ─────────────────────────────────────────────────────────
+    val gallery: String
+    val file: String
+    val all: String
+    val noGalleryAccess: String
+    val openGallery: String
+    fun attachNPhotos(n: Int): String
+    val muteNotifications: String
+    val mute1Hour: String
+    val mute8Hours: String
+    val mute24Hours: String
+    val muteForever: String
+    val deleteChatTitle: String
+    val deleteChat: String
+    val deleteChatMessage: String
+    val deleteForAll: String
+    val clearHistory: String
+    val clearHistoryMessage: String
+    val onlyForMe: String
+    val forAll: String
+    val deleteMessageTitle: String
+    val deleteMessageText: String
+    val call: String
+    val notifications: String
+    val changeWallpaper: String
+    val reply: String
+    val voiceMessage: String
+    val photo: String
+    val swipeToCancel: String
+    val messagePlaceholder: String
+    val messageDeletedEmoji: String
+    val messageDeleted: String
+    val member: String
+    val saveToGallery: String
+    val copyText: String
+    val you: String
+    val interlocutor: String
+
+    // ── ChatViewModel (non-composable) ───────────────────────────────
+    val mlsNotReady: String
+    val encrypted: String
+    val sentFromOtherDevice: String
+    val decryptionError: String
+    fun loadError(msg: String): String
+    fun leftGroup(name: String): String
+    fun removedFromGroup(kickerName: String, kickedName: String): String
+    val admin: String
+    val encryptionNotReady: String
+    fun sendError(msg: String): String
+    val photoSendError: String
+    fun photoSendErrorDetail(msg: String): String
+    fun voiceSendError(msg: String): String
+    fun deleteError(msg: String): String
+
+    // ── Contacts ─────────────────────────────────────────────────────
+    val newContact: String
+    val enterPublicKey: String
+    val deleteContactTitle: String
+    fun deleteContactMessage(name: String): String
+    val blockTitle: String
+    fun blockMessage(name: String): String
+    val blockAction: String
+    val contactsTitle: String
+    val noContacts: String
+    val addContactHint: String
+    val favorites: String
+    val allContacts: String
+    val removeFromFavorites: String
+    val addToFavorites: String
+
+    // ── Profile ──────────────────────────────────────────────────────
+    val profileTitle: String
+    val username: String
+    val aboutMe: String
+    val copyMyPublicKey: String
+    val logout: String
+
+    // ── Group profile ────────────────────────────────────────────────
+    val roleOwner: String
+    val roleAdmin: String
+    val roleMember: String
+    val chatFallback: String
+    val leaveGroupTitle: String
+    val leaveGroupMessage: String
+    val leave: String
+    val removeMemberTitle: String
+    val userFallback: String
+    fun removeMemberMessage(name: String): String
+    val remove: String
+    val sendDM: String
+    val addToContacts: String
+    val makeAdmin: String
+    val removeAdminRole: String
+    val removeFromGroup: String
+    val selectMember: String
+    val noAvailableContacts: String
+    val noName: String
+    val groupInfo: String
+    fun membersCount(n: Int): String
+    val addMember: String
+    val leaveGroup: String
+    val searchMembers: String
+
+    // ── User profile ─────────────────────────────────────────────────
+    val sendMessage: String
+    val addToContactsButton: String
+
+    // ── Create group ─────────────────────────────────────────────────
+    val groupName: String
+    fun membersSelected(n: Int): String
+    val noContactsYet: String
+
+    // ── Privacy ──────────────────────────────────────────────────────
+    val privacyTitle: String
+    val whoSeesProfile: String
+    val whoSeesLastSeen: String
+    val deleteAccountAfter: String
+    val autoDeleteMessages: String
+    val autoDeleteOff: String
+    val autoDelete1Day: String
+    val autoDelete1Week: String
+    val autoDelete1Month: String
+    val deleteAccountTitle: String
+    val deleteAccountWarning: String
+    val blackList: String
+    val manage: String
+    val privacySection: String
+    val autoDeleteSection: String
+    val deleteAccountAction: String
+
+    // ── Privacy ViewModel ────────────────────────────────────────────
+    val visEverybody: String
+    val visContacts: String
+    val visNobody: String
+    val days1Month: String
+    val days3Months: String
+    val days6Months: String
+    val days1Year: String
+    val daysOff: String
+
+    // ── Notifications ────────────────────────────────────────────────
+    val notificationsTitle: String
+    val privateChats: String
+    val groups: String
+    val channels: String
+    val enableNotifications: String
+    val disableForever: String
+    val disableForTime: String
+    val disableForHowLong: String
+    val hours: String
+    val disable: String
+    val vibrationForCalls: String
+    val ringtone: String
+    val disabled: String
+    val enabled: String
+    val callsSection: String
+    val vibration: String
+
+    // ── Notifications ViewModel ──────────────────────────────────────
+    val vibrateNone: String
+    val vibrateWeak: String
+    val vibrateMedium: String
+    val vibrateStrong: String
+    val ringtoneDefault: String
+    val ringtoneClassic: String
+    val ringtoneSimple: String
+    val ringtoneNone: String
+
+    // ── Appearance ───────────────────────────────────────────────────
+    val appearanceTitle: String
+    val preview: String
+    val chatPreview: String
+    val previewMessage1: String
+    val previewMessage2: String
+    val topBarColor: String
+    val chatBgColor: String
+    val myMessageColor: String
+    val otherMessageColor: String
+    val chooseColor: String
+
+    // ── Storage ──────────────────────────────────────────────────────
+    val dataAndStorageTitle: String
+    val autoClearCache: String
+    val deleteOldByTime: String
+    val deleteLeastRecent: String
+    val deleteLeastRequested: String
+    val deleteOldestFifo: String
+    val messagesInChat: String
+    val storeMessagesDays: String
+    val globalLimit: String
+    val clearLocalCache: String
+    val fifoDescription: String
+    val ttlDescription: String
+    val lruDescription: String
+    val lfuDescription: String
+
+    // ── Language ─────────────────────────────────────────────────────
+    val languageTitle: String
+    val searchLanguage: String
+    val aiTranslation: String
+    val comingSoon: String
+
+    // ── Linked devices ───────────────────────────────────────────────
+    val linkedDevicesTitle: String
+    val refresh: String
+    val addDeviceByQr: String
+    val pendingConfirmation: String
+    val myDevices: String
+    val thisDevice: String
+    val revoked: String
+    val revoke: String
+    val revokeDeviceTitle: String
+    fun revokeDeviceMessage(name: String): String
+    val decline: String
+    val allow: String
+    val addDevice: String
+    val copyCodeHint: String
+    val copyCode: String
+    val codeCopied: String
+    val scanQrInstead: String
+
+    // ── Add device ───────────────────────────────────────────────────
+    val scanQrHint: String
+    val pasteCodeHint: String
+    val codeOrQrLink: String
+    val paste: String
+    val connect: String
+    val sendingDeviceData: String
+    val awaitingConfirmation: String
+    val confirmOnMainDevice: String
+    val deviceAdded: String
+    val errorOccurred: String
+    val tryAgain: String
+
+    // ── Black list ───────────────────────────────────────────────────
+    val unblockTitle: String
+    fun unblockMessage(name: String): String
+    val unblockAction: String
+    val blackListTitle: String
+    val blackListEmpty: String
+    val blockedUsersHint: String
+
+    // ── Date scrubber ────────────────────────────────────────────────
+    val mon: String
+    val tue: String
+    val wed: String
+    val thu: String
+    val fri: String
+    val sat: String
+    val sun: String
+
+    // ── App / misc ───────────────────────────────────────────────────
+    val groupDefault: String
+    val create: String
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Russian
+// ═══════════════════════════════════════════════════════════════════════
+object RuStrings : AppStrings {
+
+    // Common
+    override val cancel = "Отмена"
+    override val error = "Ошибка"
+    override val delete = "Удалить"
+    override val add = "Добавить"
+    override val save = "Сохранить"
+    override val back = "Назад"
+    override val close = "Закрыть"
+    override val search = "Поиск"
+    override val loading = "Загрузка..."
+    override val copied = "Скопировано!"
+    override val ok = "OK"
+
+    // Auth
+    override val nickname = "Никнейм"
+    override val inviteCode = "Инвайт-код"
+    override val autoLoginHint = "Вход выполнится автоматически\nс помощью ключа на устройстве"
+    override val login = "Войти"
+    override val register = "Зарегистрироваться"
+    override val noAccountRegister = "Нет аккаунта? Зарегистрироваться"
+    override val hasAccountLogin = "Уже есть аккаунт? Войти"
+    override val loginFromOtherDevice = "Войти с другого устройства"
+
+    // Settings menu
+    override val settingsAppearance = "Внешний вид"
+    override val settingsNotifications = "Уведомления"
+    override val settingsPrivacy = "Конфиденциальность"
+    override val settingsDataAndStorage = "Данные и память"
+    override val settingsContacts = "Контакты"
+    override val settingsLinkedDevices = "Связанные устройства"
+    override val settingsLanguage = "Язык"
+
+    // Chats list
+    override val searchPlaceholder = "Поиск..."
+    override val createGroup = "Создать группу"
+    override val addByKey = "Добавить по ключу"
+    override val addByQr = "Добавить по QR"
+    override val createChannel = "Создать канал"
+    override val newChat = "Новый чат"
+    override val enterPublicKeyToChat =
+        "Введите публичный ключ пользователя, чтобы добавить его в контакты и сразу начать чат."
+    override val publicKey = "Публичный ключ"
+    override val start = "Начать"
+    override val nothingFound = "Ничего не найдено"
+    override val youPrefix = "Вы: "
+
+    // Chat
+    override val gallery = "Галерея"
+    override val file = "Файл"
+    override val all = "Все"
+    override val noGalleryAccess = "Нет доступа к галерее"
+    override val openGallery = "Открыть галерею"
+    override fun attachNPhotos(n: Int) = "Прикрепить $n фото"
+    override val muteNotifications = "Отключить уведомления"
+    override val mute1Hour = "1 час"
+    override val mute8Hours = "8 часов"
+    override val mute24Hours = "24 часа"
+    override val muteForever = "Навсегда"
+    override val deleteChatTitle = "Удалить чат?"
+    override val deleteChat = "Удалить чат"
+    override val deleteChatMessage = "Чат будет удалён для всех участников."
+    override val deleteForAll = "Удалить для всех"
+    override val clearHistory = "Очистить историю"
+    override val clearHistoryMessage = "Выберите, для кого очистить историю сообщений."
+    override val onlyForMe = "Только у меня"
+    override val forAll = "У всех"
+    override val deleteMessageTitle = "Удалить сообщение?"
+    override val deleteMessageText = "Сообщение будет удалено для всех участников."
+    override val call = "Звонок"
+    override val notifications = "Уведомления"
+    override val changeWallpaper = "Сменить обои"
+    override val reply = "Ответ"
+    override val voiceMessage = "Голосовое сообщение"
+    override val photo = "Фото"
+    override val swipeToCancel = "< Свайп для отмены"
+    override val messagePlaceholder = "Сообщение..."
+    override val messageDeletedEmoji = "\uD83D\uDDD1 Сообщение удалено"
+    override val messageDeleted = "Сообщение удалено"
+    override val member = "Участник"
+    override val saveToGallery = "Сохранить в галерею"
+    override val copyText = "Копировать текст"
+    override val you = "Вы"
+    override val interlocutor = "Собеседник"
+
+    // ChatViewModel
+    override val mlsNotReady = "MLS не готов для этого чата"
+    override val encrypted = "\uD83D\uDD12 [Зашифровано]"
+    override val sentFromOtherDevice = "\uD83D\uDD12 [Отправлено с другого устройства]"
+    override val decryptionError = "\uD83D\uDD12 [Ошибка расшифровки]"
+    override fun loadError(msg: String) = "Ошибка загрузки: $msg"
+    override fun leftGroup(name: String) = "$name покинул(а) группу"
+    override fun removedFromGroup(kickerName: String, kickedName: String) =
+        "$kickerName удалил(а) $kickedName из группы"
+    override val admin = "Администратор"
+    override val encryptionNotReady = "⚠\uFE0F Шифрование не готово"
+    override fun sendError(msg: String) = "Ошибка отправки: $msg"
+    override val photoSendError = "❌ Ошибка отправки фото"
+    override fun photoSendErrorDetail(msg: String) = "Ошибка отправки фото: $msg"
+    override fun voiceSendError(msg: String) = "Ошибка отправки голосового: $msg"
+    override fun deleteError(msg: String) = "Ошибка удаления: $msg"
+
+    // Contacts
+    override val newContact = "Новый контакт"
+    override val enterPublicKey = "Введите публичный ключ пользователя"
+    override val deleteContactTitle = "Удалить контакт?"
+    override fun deleteContactMessage(name: String) = "Удалить $name из контактов?"
+    override val blockTitle = "Заблокировать?"
+    override fun blockMessage(name: String) = "Заблокировать $name? Он будет удалён из контактов."
+    override val blockAction = "Заблокировать"
+    override val contactsTitle = "Контакты"
+    override val noContacts = "Нет контактов"
+    override val addContactHint = "Нажмите + чтобы добавить контакт\nпо публичному ключу"
+    override val favorites = "⭐ Избранные"
+    override val allContacts = "Все контакты"
+    override val removeFromFavorites = "Убрать из избранного"
+    override val addToFavorites = "В избранное"
+
+    // Profile
+    override val profileTitle = "Профиль"
+    override val username = "Имя пользователя"
+    override val aboutMe = "О себе"
+    override val copyMyPublicKey = "Скопировать мой публичный ключ"
+    override val logout = "Выйти из аккаунта"
+
+    // Group profile
+    override val roleOwner = "Владелец"
+    override val roleAdmin = "Администратор"
+    override val roleMember = "Участник"
+    override val chatFallback = "Чат"
+    override val leaveGroupTitle = "Покинуть группу?"
+    override val leaveGroupMessage = "Вы больше не будете получать сообщения из этого чата."
+    override val leave = "Покинуть"
+    override val removeMemberTitle = "Удалить участника?"
+    override val userFallback = "Пользователь"
+    override fun removeMemberMessage(name: String) = "$name будет удален из группы."
+    override val remove = "Удалить"
+    override val sendDM = "Написать в ЛС"
+    override val addToContacts = "Добавить в контакты"
+    override val makeAdmin = "Назначить администратором"
+    override val removeAdminRole = "Снять администратора"
+    override val removeFromGroup = "Удалить из группы"
+    override val selectMember = "Выберите участника"
+    override val noAvailableContacts = "Нет доступных контактов для добавления"
+    override val noName = "Без имени"
+    override val groupInfo = "Информация о группе"
+    override fun membersCount(n: Int) = "$n участников"
+    override val addMember = "Добавить участника"
+    override val leaveGroup = "Покинуть группу"
+    override val searchMembers = "Поиск участников..."
+
+    // User profile
+    override val sendMessage = "Написать"
+    override val addToContactsButton = "В контакты"
+
+    // Create group
+    override val groupName = "Название группы"
+    override fun membersSelected(n: Int) = "Участники ($n выбрано)"
+    override val noContactsYet = "У вас пока нет контактов"
+
+    // Privacy
+    override val privacyTitle = "Конфиденциальность"
+    override val whoSeesProfile = "Кто видит мой профиль"
+    override val whoSeesLastSeen = "Кто видит время активности"
+    override val deleteAccountAfter = "Удалить аккаунт через"
+    override val autoDeleteMessages = "Авто-удаление сообщений"
+    override val autoDeleteOff = "Выкл"
+    override val autoDelete1Day = "1 день"
+    override val autoDelete1Week = "1 неделя"
+    override val autoDelete1Month = "1 месяц"
+    override val deleteAccountTitle = "Удалить аккаунт?"
+    override val deleteAccountWarning = "Это действие необратимо. Все данные будут удалены."
+    override val blackList = "Чёрный список"
+    override val manage = "Управление"
+    override val privacySection = "Приватность"
+    override val autoDeleteSection = "Авто-удаление"
+    override val deleteAccountAction = "Удалить аккаунт"
+
+    // Privacy ViewModel
+    override val visEverybody = "Все"
+    override val visContacts = "Контакты"
+    override val visNobody = "Никто"
+    override val days1Month = "1 месяц"
+    override val days3Months = "3 месяца"
+    override val days6Months = "6 месяцев"
+    override val days1Year = "1 год"
+    override val daysOff = "Выкл"
+
+    // Notifications
+    override val notificationsTitle = "Уведомления"
+    override val privateChats = "Личные чаты"
+    override val groups = "Группы"
+    override val channels = "Каналы"
+    override val enableNotifications = "Включить уведомления"
+    override val disableForever = "Отключить навсегда"
+    override val disableForTime = "Отключить на время..."
+    override val disableForHowLong = "Отключить на сколько часов?"
+    override val hours = "Часы"
+    override val disable = "Отключить"
+    override val vibrationForCalls = "Вибрация для звонков"
+    override val ringtone = "Мелодия звонка"
+    override val disabled = "Отключено"
+    override val enabled = "Включено"
+    override val callsSection = "ЗВОНКИ"
+    override val vibration = "Вибрация"
+
+    // Notifications ViewModel
+    override val vibrateNone = "Нет"
+    override val vibrateWeak = "Слабая"
+    override val vibrateMedium = "Средняя"
+    override val vibrateStrong = "Сильная"
+    override val ringtoneDefault = "Default"
+    override val ringtoneClassic = "Классический"
+    override val ringtoneSimple = "Простой"
+    override val ringtoneNone = "Нет"
+
+    // Appearance
+    override val appearanceTitle = "Внешний вид"
+    override val preview = "Предпросмотр"
+    override val chatPreview = "Чат"
+    override val previewMessage1 = "Привет! Как дела?"
+    override val previewMessage2 = "Всё супер, тестирую Compose!"
+    override val topBarColor = "Цвет верхней панели"
+    override val chatBgColor = "Цвет фона чата"
+    override val myMessageColor = "Цвет моих сообщений"
+    override val otherMessageColor = "Цвет чужих сообщений"
+    override val chooseColor = "Выберите цвет"
+
+    // Storage
+    override val dataAndStorageTitle = "Данные и память"
+    override val autoClearCache = "Автоматическая очистка кэша"
+    override val deleteOldByTime = "Удалять старые по времени (1 месяц)"
+    override val deleteLeastRecent = "Удалять наименее недавно использованные"
+    override val deleteLeastRequested = "Удалять реже всего запрашиваемые"
+    override val deleteOldestFifo = "Удалять самые старые (FIFO)"
+    override val messagesInChat = "Сообщений в чате (последних)"
+    override val storeMessagesDays = "Хранить сообщения (дней)"
+    override val globalLimit = "Глобальный лимит (сообщений)"
+    override val clearLocalCache = "Очистить локальный кэш сейчас"
+    override val fifoDescription = "Старые сообщения сверх лимита будут удалены из этого чата"
+    override val ttlDescription = "Сообщения старше указанного периода удаляются автоматически"
+    override val lruDescription = "Удаляются сообщения из чатов, которые давно не открывались"
+    override val lfuDescription = "Удаляются сообщения из чатов, в которые реже всего заходят"
+
+    // Language
+    override val languageTitle = "Язык"
+    override val searchLanguage = "Поиск языка..."
+    override val aiTranslation = "AI-перевод"
+    override val comingSoon = "Скоро..."
+
+    // Linked devices
+    override val linkedDevicesTitle = "Связанные устройства"
+    override val refresh = "Обновить"
+    override val addDeviceByQr = "Добавить устройство по QR"
+    override val pendingConfirmation = "Ожидают подтверждения"
+    override val myDevices = "Мои устройства"
+    override val thisDevice = "это устройство"
+    override val revoked = "Отозвано"
+    override val revoke = "Отозвать"
+    override val revokeDeviceTitle = "Отозвать устройство?"
+    override fun revokeDeviceMessage(name: String) = "'$name' будет удалено из вашего аккаунта."
+    override val decline = "Отклонить"
+    override val allow = "Разрешить"
+    override val addDevice = "Добавить устройство"
+    override val copyCodeHint = "Или скопируйте код и вставьте его на новом устройстве"
+    override val copyCode = "Скопировать код"
+    override val codeCopied = "✓ Скопировано"
+    override val scanQrInstead = "Хочу отсканировать QR вместо этого"
+
+    // Add device
+    override val scanQrHint = "Отсканируй QR-код\nс основного устройства"
+    override val pasteCodeHint = "Или вставьте код с другого устройства"
+    override val codeOrQrLink = "Код или QR-ссылка"
+    override val paste = "Вставить"
+    override val connect = "Подключить"
+    override val sendingDeviceData = "Отправка данных устройства..."
+    override val awaitingConfirmation = "Ожидаем подтверждения\nот основного устройства"
+    override val confirmOnMainDevice =
+        "Зайди на основном телефоне в\nНастройки → Связанные устройства\nи нажми «Разрешить»"
+    override val deviceAdded = "Устройство добавлено!"
+    override val errorOccurred = "Произошла ошибка"
+    override val tryAgain = "Попробовать снова"
+
+    // Black list
+    override val unblockTitle = "Разблокировать?"
+    override fun unblockMessage(name: String) = "Разблокировать $name?"
+    override val unblockAction = "Разблокировать"
+    override val blackListTitle = "Чёрный список"
+    override val blackListEmpty = "Чёрный список пуст"
+    override val blockedUsersHint = "Заблокированные пользователи появятся здесь"
+
+    // Date scrubber
+    override val mon = "Пн"
+    override val tue = "Вт"
+    override val wed = "Ср"
+    override val thu = "Чт"
+    override val fri = "Пт"
+    override val sat = "Сб"
+    override val sun = "Вс"
+
+    // App / misc
+    override val groupDefault = "Группа"
+    override val create = "Создать"
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// English
+// ═══════════════════════════════════════════════════════════════════════
+object EnStrings : AppStrings {
+
+    // Common
+    override val cancel = "Cancel"
+    override val error = "Error"
+    override val delete = "Delete"
+    override val add = "Add"
+    override val save = "Save"
+    override val back = "Back"
+    override val close = "Close"
+    override val search = "Search"
+    override val loading = "Loading..."
+    override val copied = "Copied!"
+    override val ok = "OK"
+
+    // Auth
+    override val nickname = "Nickname"
+    override val inviteCode = "Invite code"
+    override val autoLoginHint = "Login will happen automatically\nusing the key on this device"
+    override val login = "Log in"
+    override val register = "Sign up"
+    override val noAccountRegister = "No account? Sign up"
+    override val hasAccountLogin = "Already have an account? Log in"
+    override val loginFromOtherDevice = "Log in from another device"
+
+    // Settings menu
+    override val settingsAppearance = "Appearance"
+    override val settingsNotifications = "Notifications"
+    override val settingsPrivacy = "Privacy"
+    override val settingsDataAndStorage = "Data and Storage"
+    override val settingsContacts = "Contacts"
+    override val settingsLinkedDevices = "Linked Devices"
+    override val settingsLanguage = "Language"
+
+    // Chats list
+    override val searchPlaceholder = "Search..."
+    override val createGroup = "Create group"
+    override val addByKey = "Add by key"
+    override val addByQr = "Add by QR"
+    override val createChannel = "Create channel"
+    override val newChat = "New chat"
+    override val enterPublicKeyToChat =
+        "Enter the user's public key to add them to contacts and start a chat."
+    override val publicKey = "Public key"
+    override val start = "Start"
+    override val nothingFound = "Nothing found"
+    override val youPrefix = "You: "
+
+    // Chat
+    override val gallery = "Gallery"
+    override val file = "File"
+    override val all = "All"
+    override val noGalleryAccess = "No gallery access"
+    override val openGallery = "Open gallery"
+    override fun attachNPhotos(n: Int) = "Attach $n photo${if (n == 1) "" else "s"}"
+    override val muteNotifications = "Mute notifications"
+    override val mute1Hour = "1 hour"
+    override val mute8Hours = "8 hours"
+    override val mute24Hours = "24 hours"
+    override val muteForever = "Forever"
+    override val deleteChatTitle = "Delete chat?"
+    override val deleteChat = "Delete chat"
+    override val deleteChatMessage = "The chat will be deleted for all participants."
+    override val deleteForAll = "Delete for everyone"
+    override val clearHistory = "Clear history"
+    override val clearHistoryMessage = "Choose who to clear message history for."
+    override val onlyForMe = "Only for me"
+    override val forAll = "For everyone"
+    override val deleteMessageTitle = "Delete message?"
+    override val deleteMessageText = "The message will be deleted for all participants."
+    override val call = "Call"
+    override val notifications = "Notifications"
+    override val changeWallpaper = "Change wallpaper"
+    override val reply = "Reply"
+    override val voiceMessage = "Voice message"
+    override val photo = "Photo"
+    override val swipeToCancel = "< Swipe to cancel"
+    override val messagePlaceholder = "Message..."
+    override val messageDeletedEmoji = "\uD83D\uDDD1 Message deleted"
+    override val messageDeleted = "Message deleted"
+    override val member = "Member"
+    override val saveToGallery = "Save to gallery"
+    override val copyText = "Copy text"
+    override val you = "You"
+    override val interlocutor = "Contact"
+
+    // ChatViewModel
+    override val mlsNotReady = "MLS is not ready for this chat"
+    override val encrypted = "\uD83D\uDD12 [Encrypted]"
+    override val sentFromOtherDevice = "\uD83D\uDD12 [Sent from another device]"
+    override val decryptionError = "\uD83D\uDD12 [Decryption error]"
+    override fun loadError(msg: String) = "Loading error: $msg"
+    override fun leftGroup(name: String) = "$name left the group"
+    override fun removedFromGroup(kickerName: String, kickedName: String) =
+        "$kickerName removed $kickedName from the group"
+    override val admin = "Admin"
+    override val encryptionNotReady = "⚠\uFE0F Encryption not ready"
+    override fun sendError(msg: String) = "Send error: $msg"
+    override val photoSendError = "❌ Photo send error"
+    override fun photoSendErrorDetail(msg: String) = "Photo send error: $msg"
+    override fun voiceSendError(msg: String) = "Voice send error: $msg"
+    override fun deleteError(msg: String) = "Delete error: $msg"
+
+    // Contacts
+    override val newContact = "New contact"
+    override val enterPublicKey = "Enter the user's public key"
+    override val deleteContactTitle = "Delete contact?"
+    override fun deleteContactMessage(name: String) = "Delete $name from contacts?"
+    override val blockTitle = "Block?"
+    override fun blockMessage(name: String) = "Block $name? They will be removed from contacts."
+    override val blockAction = "Block"
+    override val contactsTitle = "Contacts"
+    override val noContacts = "No contacts"
+    override val addContactHint = "Tap + to add a contact\nby public key"
+    override val favorites = "⭐ Favorites"
+    override val allContacts = "All contacts"
+    override val removeFromFavorites = "Remove from favorites"
+    override val addToFavorites = "Add to favorites"
+
+    // Profile
+    override val profileTitle = "Profile"
+    override val username = "Username"
+    override val aboutMe = "About"
+    override val copyMyPublicKey = "Copy my public key"
+    override val logout = "Log out"
+
+    // Group profile
+    override val roleOwner = "Owner"
+    override val roleAdmin = "Admin"
+    override val roleMember = "Member"
+    override val chatFallback = "Chat"
+    override val leaveGroupTitle = "Leave group?"
+    override val leaveGroupMessage = "You will no longer receive messages from this chat."
+    override val leave = "Leave"
+    override val removeMemberTitle = "Remove member?"
+    override val userFallback = "User"
+    override fun removeMemberMessage(name: String) = "$name will be removed from the group."
+    override val remove = "Remove"
+    override val sendDM = "Send direct message"
+    override val addToContacts = "Add to contacts"
+    override val makeAdmin = "Make admin"
+    override val removeAdminRole = "Remove admin"
+    override val removeFromGroup = "Remove from group"
+    override val selectMember = "Select member"
+    override val noAvailableContacts = "No contacts available to add"
+    override val noName = "No name"
+    override val groupInfo = "Group info"
+    override fun membersCount(n: Int) = "$n member${if (n == 1) "" else "s"}"
+    override val addMember = "Add member"
+    override val leaveGroup = "Leave group"
+    override val searchMembers = "Search members..."
+
+    // User profile
+    override val sendMessage = "Message"
+    override val addToContactsButton = "Add to contacts"
+
+    // Create group
+    override val groupName = "Group name"
+    override fun membersSelected(n: Int) = "Members ($n selected)"
+    override val noContactsYet = "You have no contacts yet"
+
+    // Privacy
+    override val privacyTitle = "Privacy"
+    override val whoSeesProfile = "Who can see my profile"
+    override val whoSeesLastSeen = "Who can see my last seen"
+    override val deleteAccountAfter = "Delete account after"
+    override val autoDeleteMessages = "Auto-delete messages"
+    override val autoDeleteOff = "Off"
+    override val autoDelete1Day = "1 day"
+    override val autoDelete1Week = "1 week"
+    override val autoDelete1Month = "1 month"
+    override val deleteAccountTitle = "Delete account?"
+    override val deleteAccountWarning = "This action is irreversible. All data will be deleted."
+    override val blackList = "Blacklist"
+    override val manage = "Manage"
+    override val privacySection = "Privacy"
+    override val autoDeleteSection = "Auto-delete"
+    override val deleteAccountAction = "Delete account"
+
+    // Privacy ViewModel
+    override val visEverybody = "Everybody"
+    override val visContacts = "Contacts"
+    override val visNobody = "Nobody"
+    override val days1Month = "1 month"
+    override val days3Months = "3 months"
+    override val days6Months = "6 months"
+    override val days1Year = "1 year"
+    override val daysOff = "Off"
+
+    // Notifications
+    override val notificationsTitle = "Notifications"
+    override val privateChats = "Private chats"
+    override val groups = "Groups"
+    override val channels = "Channels"
+    override val enableNotifications = "Enable notifications"
+    override val disableForever = "Disable permanently"
+    override val disableForTime = "Disable for a while..."
+    override val disableForHowLong = "Disable for how many hours?"
+    override val hours = "Hours"
+    override val disable = "Disable"
+    override val vibrationForCalls = "Vibration for calls"
+    override val ringtone = "Ringtone"
+    override val disabled = "Disabled"
+    override val enabled = "Enabled"
+    override val callsSection = "CALLS"
+    override val vibration = "Vibration"
+
+    // Notifications ViewModel
+    override val vibrateNone = "None"
+    override val vibrateWeak = "Weak"
+    override val vibrateMedium = "Medium"
+    override val vibrateStrong = "Strong"
+    override val ringtoneDefault = "Default"
+    override val ringtoneClassic = "Classic"
+    override val ringtoneSimple = "Simple"
+    override val ringtoneNone = "None"
+
+    // Appearance
+    override val appearanceTitle = "Appearance"
+    override val preview = "Preview"
+    override val chatPreview = "Chat"
+    override val previewMessage1 = "Hey! How are you?"
+    override val previewMessage2 = "Great, testing Compose!"
+    override val topBarColor = "Top bar color"
+    override val chatBgColor = "Chat background color"
+    override val myMessageColor = "My message color"
+    override val otherMessageColor = "Other message color"
+    override val chooseColor = "Choose color"
+
+    // Storage
+    override val dataAndStorageTitle = "Data and Storage"
+    override val autoClearCache = "Automatic cache cleanup"
+    override val deleteOldByTime = "Delete old by time (1 month)"
+    override val deleteLeastRecent = "Delete least recently used"
+    override val deleteLeastRequested = "Delete least frequently requested"
+    override val deleteOldestFifo = "Delete oldest (FIFO)"
+    override val messagesInChat = "Messages in chat (recent)"
+    override val storeMessagesDays = "Store messages (days)"
+    override val globalLimit = "Global limit (messages)"
+    override val clearLocalCache = "Clear local cache now"
+    override val fifoDescription = "Old messages beyond the limit will be removed from this chat"
+    override val ttlDescription = "Messages older than the specified period are deleted automatically"
+    override val lruDescription = "Messages are deleted from chats that haven't been opened for a long time"
+    override val lfuDescription = "Messages are deleted from the least frequently accessed chats"
+
+    // Language
+    override val languageTitle = "Language"
+    override val searchLanguage = "Search language..."
+    override val aiTranslation = "AI Translation"
+    override val comingSoon = "Coming soon..."
+
+    // Linked devices
+    override val linkedDevicesTitle = "Linked Devices"
+    override val refresh = "Refresh"
+    override val addDeviceByQr = "Add device via QR"
+    override val pendingConfirmation = "Pending confirmation"
+    override val myDevices = "My devices"
+    override val thisDevice = "this device"
+    override val revoked = "Revoked"
+    override val revoke = "Revoke"
+    override val revokeDeviceTitle = "Revoke device?"
+    override fun revokeDeviceMessage(name: String) = "'$name' will be removed from your account."
+    override val decline = "Decline"
+    override val allow = "Allow"
+    override val addDevice = "Add device"
+    override val copyCodeHint = "Or copy the code and paste it on the new device"
+    override val copyCode = "Copy code"
+    override val codeCopied = "✓ Copied"
+    override val scanQrInstead = "I want to scan a QR instead"
+
+    // Add device
+    override val scanQrHint = "Scan the QR code\nfrom your main device"
+    override val pasteCodeHint = "Or paste a code from another device"
+    override val codeOrQrLink = "Code or QR link"
+    override val paste = "Paste"
+    override val connect = "Connect"
+    override val sendingDeviceData = "Sending device data..."
+    override val awaitingConfirmation = "Awaiting confirmation\nfrom the main device"
+    override val confirmOnMainDevice =
+        "On your main phone go to\nSettings \u2192 Linked Devices\nand tap \"Allow\""
+    override val deviceAdded = "Device added!"
+    override val errorOccurred = "An error occurred"
+    override val tryAgain = "Try again"
+
+    // Black list
+    override val unblockTitle = "Unblock?"
+    override fun unblockMessage(name: String) = "Unblock $name?"
+    override val unblockAction = "Unblock"
+    override val blackListTitle = "Blacklist"
+    override val blackListEmpty = "Blacklist is empty"
+    override val blockedUsersHint = "Blocked users will appear here"
+
+    // Date scrubber
+    override val mon = "Mon"
+    override val tue = "Tue"
+    override val wed = "Wed"
+    override val thu = "Thu"
+    override val fri = "Fri"
+    override val sat = "Sat"
+    override val sun = "Sun"
+
+    // App / misc
+    override val groupDefault = "Group"
+    override val create = "Create"
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Composition local for @Composable access
+// ═══════════════════════════════════════════════════════════════════════
+val LocalStrings = staticCompositionLocalOf<AppStrings> { EnStrings }
+
+// ═══════════════════════════════════════════════════════════════════════
+// Global singleton for ViewModel / non-composable access
+// ═══════════════════════════════════════════════════════════════════════
+object S {
+    var current: AppStrings = EnStrings
+}

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/utils/GallerySaver.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/utils/GallerySaver.kt
@@ -1,0 +1,3 @@
+package com.example.memegram.utils
+
+expect fun saveImageToGallery(bytes: ByteArray, filename: String): Boolean

--- a/android-ios-app/composeApp/src/iosMain/kotlin/com/example/memegram/audio/AudioPlatform.ios.kt
+++ b/android-ios-app/composeApp/src/iosMain/kotlin/com/example/memegram/audio/AudioPlatform.ios.kt
@@ -101,7 +101,6 @@ class AudioPlayerIOS : AudioPlayer {
     }
 
     override fun stop() {
-        onCompletionCallback?.invoke()
         onCompletionCallback = null
 
         player?.stop()
@@ -117,5 +116,15 @@ class AudioPlayerIOS : AudioPlayer {
         val p = player ?: return 0f
         if (p.duration == 0.0) return 0f
         return (p.currentTime / p.duration).toFloat().coerceIn(0f, 1f)
+    }
+
+    override fun getDurationMs(): Long {
+        val p = player ?: return 0L
+        return (p.duration * 1000.0).toLong()
+    }
+
+    override fun seekTo(fraction: Float) {
+        val p = player ?: return
+        p.currentTime = (fraction.coerceIn(0f, 1f).toDouble() * p.duration)
     }
 }

--- a/android-ios-app/composeApp/src/iosMain/kotlin/com/example/memegram/utils/GallerySaver.ios.kt
+++ b/android-ios-app/composeApp/src/iosMain/kotlin/com/example/memegram/utils/GallerySaver.ios.kt
@@ -1,0 +1,24 @@
+package com.example.memegram.utils
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.Foundation.create
+import platform.UIKit.UIImage
+import platform.UIKit.UIImageWriteToSavedPhotosAlbum
+
+@OptIn(ExperimentalForeignApi::class)
+actual fun saveImageToGallery(bytes: ByteArray, filename: String): Boolean {
+    return try {
+        val nsData = bytes.usePinned { pinned ->
+            NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
+        }
+        val image = UIImage(data = nsData) ?: return false
+        UIImageWriteToSavedPhotosAlbum(image, null, null, null)
+        true
+    } catch (e: Exception) {
+        println("MemegramDebug [GallerySaver]: Failed to save image: ${e.message}")
+        false
+    }
+}

--- a/android-ios-app/gradle/libs.versions.toml
+++ b/android-ios-app/gradle/libs.versions.toml
@@ -62,7 +62,6 @@ qrose = { module = "io.github.alexzhirkevich:qrose", version.ref = "qrose" }
 runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "runtime" }
 ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 multiplatform-crypto-libsodium = { module = "com.ionspin.kotlin:multiplatform-crypto-libsodium-bindings", version.ref = "libsodium" }
-multiplatform-settings-keychain = { module = "com.russhwolf:multiplatform-settings-keychain", version.ref = "multiplatform-settings" }
 sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "coroutinesExtensions" }
 sqlcipher-android = { module = "net.zetetic:sqlcipher-android", version.ref = "sqlcipher" }
 

--- a/backend/messaging-service/app/grpc_handlers/conversation_handler.py
+++ b/backend/messaging-service/app/grpc_handlers/conversation_handler.py
@@ -127,6 +127,43 @@ class ConversationHandler:
                 _set_error_from_value_error(context, e)
                 return messaging_pb2.LeaveConversationResponse()
 
+    async def kick_member(self, request, context):
+        if not request.user_id or not request.conversation_id or not request.target_user_id:
+            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+            context.set_details("user_id, conversation_id, and target_user_id are required")
+            return messaging_pb2.KickMemberResponse()
+
+        async with self._container.request_scope() as scope:
+            try:
+                success = await scope.conversation_service.kick_member(
+                    caller_user_id=uuid.UUID(request.user_id),
+                    conversation_id=uuid.UUID(request.conversation_id),
+                    target_user_id=uuid.UUID(request.target_user_id),
+                )
+                return messaging_pb2.KickMemberResponse(success=success)
+            except ValueError as e:
+                _set_error_from_value_error(context, e)
+                return messaging_pb2.KickMemberResponse()
+
+    async def update_member_role(self, request, context):
+        if not request.user_id or not request.conversation_id or not request.target_user_id or not request.new_role:
+            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+            context.set_details("user_id, conversation_id, target_user_id, and new_role are required")
+            return messaging_pb2.UpdateMemberRoleResponse()
+
+        async with self._container.request_scope() as scope:
+            try:
+                success = await scope.conversation_service.update_member_role(
+                    caller_user_id=uuid.UUID(request.user_id),
+                    conversation_id=uuid.UUID(request.conversation_id),
+                    target_user_id=uuid.UUID(request.target_user_id),
+                    new_role=request.new_role,
+                )
+                return messaging_pb2.UpdateMemberRoleResponse(success=success)
+            except ValueError as e:
+                _set_error_from_value_error(context, e)
+                return messaging_pb2.UpdateMemberRoleResponse()
+
     @staticmethod
     def _to_response(result) -> messaging_pb2.ConversationResponse:
         return messaging_pb2.ConversationResponse(

--- a/backend/messaging-service/app/grpc_handlers/messaging_handler.py
+++ b/backend/messaging-service/app/grpc_handlers/messaging_handler.py
@@ -55,6 +55,12 @@ class MessagingHandler(messaging_pb2_grpc.MessagingServiceServicer):
     async def LeaveConversation(self, request, context):
         return await self._conversations.leave_conversation(request, context)
 
+    async def KickMember(self, request, context):
+        return await self._conversations.kick_member(request, context)
+
+    async def UpdateMemberRole(self, request, context):
+        return await self._conversations.update_member_role(request, context)
+
     # ── Messages ────────────────────────────────────
 
     async def SendMessage(self, request, context):

--- a/backend/messaging-service/app/grpc_handlers/presence_handler.py
+++ b/backend/messaging-service/app/grpc_handlers/presence_handler.py
@@ -127,6 +127,24 @@ def _event_to_proto(event: dict) -> messaging_pb2.ConversationEvent | None:
             member_left=messaging_pb2.MemberEvent(user_id=event["user_id"]),
         )
 
+    if event_type == "member_kicked":
+        return messaging_pb2.ConversationEvent(
+            conversation_id=conv_id,
+            member_kicked=messaging_pb2.MemberKickedEvent(
+                user_id=event["user_id"],
+                kicked_by=event.get("kicked_by", ""),
+            ),
+        )
+
+    if event_type == "role_changed":
+        return messaging_pb2.ConversationEvent(
+            conversation_id=conv_id,
+            role_changed=messaging_pb2.RoleChangedEvent(
+                user_id=event["user_id"],
+                new_role=event.get("new_role", ""),
+            ),
+        )
+
     if event_type == "epoch_changed":
         return messaging_pb2.ConversationEvent(
             conversation_id=conv_id,

--- a/backend/messaging-service/app/repositories/member_repo.py
+++ b/backend/messaging-service/app/repositories/member_repo.py
@@ -74,3 +74,13 @@ class MemberRepository(BaseRepository[ConversationMember]):
         )
         result = await self.session.execute(query)
         return result.scalar_one_or_none() is not None
+
+    async def update_role(
+        self, conversation_id: uuid.UUID, user_id: uuid.UUID, new_role: str,
+    ) -> Optional[ConversationMember]:
+        member = await self.get_active_member(conversation_id, user_id)
+        if not member:
+            return None
+        member.role = new_role
+        await self.session.flush()
+        return member

--- a/backend/messaging-service/app/services/conversation_service.py
+++ b/backend/messaging-service/app/services/conversation_service.py
@@ -72,7 +72,7 @@ class ConversationServiceImpl(IConversationService):
         initiator_member = await self._members.create({
             "conversation_id": conv.id,
             "user_id": initiator_user_id,
-            "role": "member",
+            "role": "owner",
         })
         recipient_member = await self._members.create({
             "conversation_id": conv.id,
@@ -235,6 +235,99 @@ class ConversationServiceImpl(IConversationService):
         await self._stream.publish_event(conversation_id, {
             "event_type": "member_left",
             "user_id": str(user_id),
+        })
+
+        return True
+
+    # ── KickMember ──────────────────────────────────
+
+    async def kick_member(
+        self,
+        caller_user_id: uuid.UUID,
+        conversation_id: uuid.UUID,
+        target_user_id: uuid.UUID,
+    ) -> bool:
+        # Verify caller is an active admin/owner
+        caller = await self._members.get_active_member(conversation_id, caller_user_id)
+        if not caller:
+            raise ValueError("NOT_FOUND: Not a member of this conversation")
+        if caller.role not in ("owner", "admin"):
+            raise ValueError("PERMISSION_DENIED: Only admins can kick members")
+
+        # Cannot kick yourself (use leave instead)
+        if caller_user_id == target_user_id:
+            raise ValueError("INVALID_ARGUMENT: Cannot kick yourself — use leave instead")
+
+        # Verify target is an active member
+        target = await self._members.get_active_member(conversation_id, target_user_id)
+        if not target:
+            raise ValueError("NOT_FOUND: Target user is not an active member")
+
+        # Cannot kick the owner
+        if target.role == "owner":
+            raise ValueError("PERMISSION_DENIED: Cannot kick the group owner")
+
+        # Admins cannot kick other admins (only owner can)
+        if target.role == "admin" and caller.role != "owner":
+            raise ValueError("PERMISSION_DENIED: Only the owner can kick admins")
+
+        # Mark as left
+        await self._members.update(target, {"left_at": datetime.utcnow()})
+
+        await self._stream.publish_event(conversation_id, {
+            "event_type": "member_kicked",
+            "user_id": str(target_user_id),
+            "kicked_by": str(caller_user_id),
+        })
+
+        return True
+
+    # ── UpdateMemberRole ────────────────────────────
+
+    async def update_member_role(
+        self,
+        caller_user_id: uuid.UUID,
+        conversation_id: uuid.UUID,
+        target_user_id: uuid.UUID,
+        new_role: str,
+    ) -> bool:
+        if new_role not in ("admin", "member"):
+            raise ValueError("INVALID_ARGUMENT: Role must be 'admin' or 'member'")
+
+        # Verify caller is an active admin/owner
+        caller = await self._members.get_active_member(conversation_id, caller_user_id)
+        if not caller:
+            raise ValueError("NOT_FOUND: Not a member of this conversation")
+        if caller.role not in ("owner", "admin"):
+            raise ValueError("PERMISSION_DENIED: Only admins can change roles")
+
+        # Cannot change own role
+        if caller_user_id == target_user_id:
+            raise ValueError("INVALID_ARGUMENT: Cannot change your own role")
+
+        # Verify target is an active member
+        target = await self._members.get_active_member(conversation_id, target_user_id)
+        if not target:
+            raise ValueError("NOT_FOUND: Target user is not an active member")
+
+        # Cannot change owner's role
+        if target.role == "owner":
+            raise ValueError("PERMISSION_DENIED: Cannot change the owner's role")
+
+        # Only owner can demote admins
+        if target.role == "admin" and new_role == "member" and caller.role != "owner":
+            raise ValueError("PERMISSION_DENIED: Only the owner can demote admins")
+
+        # No-op if already that role
+        if target.role == new_role:
+            return True
+
+        await self._members.update_role(conversation_id, target_user_id, new_role)
+
+        await self._stream.publish_event(conversation_id, {
+            "event_type": "role_changed",
+            "user_id": str(target_user_id),
+            "new_role": new_role,
         })
 
         return True

--- a/backend/messaging-service/app/services/interfaces/conversation_service.py
+++ b/backend/messaging-service/app/services/interfaces/conversation_service.py
@@ -91,3 +91,22 @@ class IConversationService(ABC):
         commit_data: bytes,
     ) -> bool:
         ...
+
+    @abstractmethod
+    async def kick_member(
+        self,
+        caller_user_id: uuid.UUID,
+        conversation_id: uuid.UUID,
+        target_user_id: uuid.UUID,
+    ) -> bool:
+        ...
+
+    @abstractmethod
+    async def update_member_role(
+        self,
+        caller_user_id: uuid.UUID,
+        conversation_id: uuid.UUID,
+        target_user_id: uuid.UUID,
+        new_role: str,
+    ) -> bool:
+        ...

--- a/backend/messaging-service/app/services/mls_service.py
+++ b/backend/messaging-service/app/services/mls_service.py
@@ -132,6 +132,16 @@ class MlsServiceImpl(IMlsService):
         if not mls_group:
             raise ValueError("NOT_FOUND: MLS group not found")
 
+        # Role check: only admins/owners may add or remove members
+        if added_user_ids or removed_device_ids:
+            has_admin = await self._members.has_role(
+                conversation_id, user_id, ["owner", "admin"],
+            )
+            if not has_admin:
+                raise ValueError(
+                    "PERMISSION_DENIED: Only admins can add or remove members"
+                )
+
         if mls_group.current_epoch + 1 != new_epoch:
             raise ValueError("ABORTED: Epoch conflict — expected "
                              f"{mls_group.current_epoch + 1}, got {new_epoch}")

--- a/backend/messaging-service/proto/messaging.proto
+++ b/backend/messaging-service/proto/messaging.proto
@@ -55,10 +55,12 @@ message ConversationEvent {
         MessageEdited  message_edited  = 3;
         MessageDeleted message_deleted = 4;
         TypingEvent    typing          = 5;
-        MemberEvent    member_joined   = 6;
-        MemberEvent    member_left     = 7;
-        EpochChanged   epoch_changed   = 8;
-        DeviceRevoked  device_revoked  = 9;
+        MemberEvent       member_joined  = 6;
+        MemberEvent       member_left    = 7;
+        EpochChanged      epoch_changed  = 8;
+        DeviceRevoked     device_revoked = 9;
+        MemberKickedEvent member_kicked  = 10;
+        RoleChangedEvent  role_changed   = 11;
     }
 }
 
@@ -79,6 +81,16 @@ message TypingEvent {
 
 message MemberEvent {
     string user_id = 1;
+}
+
+message MemberKickedEvent {
+    string user_id   = 1; // kicked member
+    string kicked_by = 2; // admin who kicked
+}
+
+message RoleChangedEvent {
+    string user_id  = 1;
+    string new_role = 2;
 }
 
 message EpochChanged {
@@ -189,6 +201,25 @@ message LeaveConversationRequest {
     bytes  commit_data     = 4;
 }
 message LeaveConversationResponse {
+    bool success = 1;
+}
+
+message KickMemberRequest {
+    string user_id         = 1; // caller (admin)
+    string conversation_id = 2;
+    string target_user_id  = 3;
+}
+message KickMemberResponse {
+    bool success = 1;
+}
+
+message UpdateMemberRoleRequest {
+    string user_id         = 1; // caller (admin)
+    string conversation_id = 2;
+    string target_user_id  = 3;
+    string new_role        = 4; // "admin" or "member"
+}
+message UpdateMemberRoleResponse {
     bool success = 1;
 }
 
@@ -426,6 +457,8 @@ service MessagingService {
     rpc GetConversations(GetConversationsRequest)                 returns (GetConversationsResponse);
     rpc GetConversation(GetConversationRequest)                   returns (ConversationResponse);
     rpc LeaveConversation(LeaveConversationRequest)               returns (LeaveConversationResponse);
+    rpc KickMember(KickMemberRequest)                             returns (KickMemberResponse);
+    rpc UpdateMemberRole(UpdateMemberRoleRequest)                 returns (UpdateMemberRoleResponse);
 
     // Messages
     rpc SendMessage(SendMessageRequest)   returns (SendMessageResponse);

--- a/backend/orchestrator/app/api/v1/messaging/router.py
+++ b/backend/orchestrator/app/api/v1/messaging/router.py
@@ -20,6 +20,9 @@ from app.api.v1.messaging.schemas import (
     ConversationSummarySchema,
     LeaveConversationRequestSchema,
     LeaveConversationResponseSchema,
+    KickMemberResponseSchema,
+    UpdateMemberRoleRequestSchema,
+    UpdateMemberRoleResponseSchema,
     SendMessageRequestSchema,
     SendMessageResponseSchema,
     MessageEntrySchema,
@@ -237,6 +240,44 @@ async def leave_conversation(
         commit_data=b64_to_bytes(body.commit_data),
     )
     return LeaveConversationResponseSchema(success=success)
+
+
+@router.post(
+    "/conversations/{conversation_id}/members/{target_user_id}/kick",
+    response_model=KickMemberResponseSchema,
+)
+async def kick_member(
+    conversation_id: str,
+    target_user_id: str,
+    session: SessionContext = Depends(get_current_session),
+    gw: IMessagingGateway = Depends(get_messaging_gateway),
+):
+    success = await gw.kick_member(
+        user_id=session.user_id,
+        conversation_id=conversation_id,
+        target_user_id=target_user_id,
+    )
+    return KickMemberResponseSchema(success=success)
+
+
+@router.patch(
+    "/conversations/{conversation_id}/members/{target_user_id}/role",
+    response_model=UpdateMemberRoleResponseSchema,
+)
+async def update_member_role(
+    conversation_id: str,
+    target_user_id: str,
+    body: UpdateMemberRoleRequestSchema,
+    session: SessionContext = Depends(get_current_session),
+    gw: IMessagingGateway = Depends(get_messaging_gateway),
+):
+    success = await gw.update_member_role(
+        user_id=session.user_id,
+        conversation_id=conversation_id,
+        target_user_id=target_user_id,
+        new_role=body.new_role,
+    )
+    return UpdateMemberRoleResponseSchema(success=success)
 
 
 # ── Messages ──────────────────────────────────────────────────────────

--- a/backend/orchestrator/app/api/v1/messaging/schemas.py
+++ b/backend/orchestrator/app/api/v1/messaging/schemas.py
@@ -109,6 +109,18 @@ class LeaveConversationResponseSchema(BaseModel):
     success: bool
 
 
+class KickMemberResponseSchema(BaseModel):
+    success: bool
+
+
+class UpdateMemberRoleRequestSchema(BaseModel):
+    new_role: str = Field(..., pattern=r"^(admin|member)$", description="'admin' or 'member'")
+
+
+class UpdateMemberRoleResponseSchema(BaseModel):
+    success: bool
+
+
 # ── Messages ──────────────────────────────────────────────────────────
 
 class SendMessageRequestSchema(BaseModel):

--- a/backend/orchestrator/app/core/interfaces/messaging_gateway.py
+++ b/backend/orchestrator/app/core/interfaces/messaging_gateway.py
@@ -209,6 +209,16 @@ class IMessagingGateway(ABC):
         self, user_id: str, device_id: str, conversation_id: str, commit_data: bytes,
     ) -> bool: ...
 
+    @abstractmethod
+    async def kick_member(
+        self, user_id: str, conversation_id: str, target_user_id: str,
+    ) -> bool: ...
+
+    @abstractmethod
+    async def update_member_role(
+        self, user_id: str, conversation_id: str, target_user_id: str, new_role: str,
+    ) -> bool: ...
+
     # Messages
     @abstractmethod
     async def send_message(

--- a/backend/orchestrator/app/infrastructure/grpc/messaging_gateway.py
+++ b/backend/orchestrator/app/infrastructure/grpc/messaging_gateway.py
@@ -260,6 +260,39 @@ class GrpcMessagingGateway(IMessagingGateway):
             raise grpc_error_to_exception(e, _SERVICE)
         return resp.success
 
+    async def kick_member(
+        self, user_id: str, conversation_id: str, target_user_id: str,
+    ) -> bool:
+        try:
+            resp = await self._stub().KickMember(
+                messaging_pb2.KickMemberRequest(
+                    user_id=user_id,
+                    conversation_id=conversation_id,
+                    target_user_id=target_user_id,
+                ),
+                timeout=self._timeout,
+            )
+        except grpc.RpcError as e:
+            raise grpc_error_to_exception(e, _SERVICE)
+        return resp.success
+
+    async def update_member_role(
+        self, user_id: str, conversation_id: str, target_user_id: str, new_role: str,
+    ) -> bool:
+        try:
+            resp = await self._stub().UpdateMemberRole(
+                messaging_pb2.UpdateMemberRoleRequest(
+                    user_id=user_id,
+                    conversation_id=conversation_id,
+                    target_user_id=target_user_id,
+                    new_role=new_role,
+                ),
+                timeout=self._timeout,
+            )
+        except grpc.RpcError as e:
+            raise grpc_error_to_exception(e, _SERVICE)
+        return resp.success
+
     # ── Messages ──────────────────────────────────────────────────────
 
     async def send_message(
@@ -578,6 +611,14 @@ class GrpcMessagingGateway(IMessagingGateway):
         elif which == "member_left":
             result["type"] = "member_left"
             result["data"] = {"user_id": event.member_left.user_id}
+        elif which == "member_kicked":
+            mk = event.member_kicked
+            result["type"] = "member_kicked"
+            result["data"] = {"user_id": mk.user_id, "kicked_by": mk.kicked_by}
+        elif which == "role_changed":
+            rc = event.role_changed
+            result["type"] = "role_changed"
+            result["data"] = {"user_id": rc.user_id, "new_role": rc.new_role}
         elif which == "epoch_changed":
             result["type"] = "epoch_changed"
             result["data"] = {"new_epoch": event.epoch_changed.new_epoch}

--- a/backend/orchestrator/proto/messaging.proto
+++ b/backend/orchestrator/proto/messaging.proto
@@ -51,14 +51,16 @@ message ConversationSummary {
 message ConversationEvent {
     string conversation_id = 1;
     oneof event {
-        MessageEntry   new_message     = 2;
-        MessageEdited  message_edited  = 3;
-        MessageDeleted message_deleted = 4;
-        TypingEvent    typing          = 5;
-        MemberEvent    member_joined   = 6;
-        MemberEvent    member_left     = 7;
-        EpochChanged   epoch_changed   = 8;
-        DeviceRevoked  device_revoked  = 9;
+        MessageEntry      new_message     = 2;
+        MessageEdited     message_edited  = 3;
+        MessageDeleted    message_deleted = 4;
+        TypingEvent       typing          = 5;
+        MemberEvent       member_joined   = 6;
+        MemberEvent       member_left     = 7;
+        EpochChanged      epoch_changed   = 8;
+        DeviceRevoked     device_revoked  = 9;
+        MemberKickedEvent member_kicked   = 10;
+        RoleChangedEvent  role_changed    = 11;
     }
 }
 
@@ -79,6 +81,16 @@ message TypingEvent {
 
 message MemberEvent {
     string user_id = 1;
+}
+
+message MemberKickedEvent {
+    string user_id   = 1; // kicked member
+    string kicked_by = 2; // admin who kicked
+}
+
+message RoleChangedEvent {
+    string user_id  = 1;
+    string new_role = 2;
 }
 
 message EpochChanged {
@@ -189,6 +201,25 @@ message LeaveConversationRequest {
     bytes  commit_data     = 4;
 }
 message LeaveConversationResponse {
+    bool success = 1;
+}
+
+message KickMemberRequest {
+    string user_id         = 1; // caller (admin)
+    string conversation_id = 2;
+    string target_user_id  = 3;
+}
+message KickMemberResponse {
+    bool success = 1;
+}
+
+message UpdateMemberRoleRequest {
+    string user_id         = 1; // caller (admin)
+    string conversation_id = 2;
+    string target_user_id  = 3;
+    string new_role        = 4; // "admin" or "member"
+}
+message UpdateMemberRoleResponse {
     bool success = 1;
 }
 
@@ -426,6 +457,8 @@ service MessagingService {
     rpc GetConversations(GetConversationsRequest)                 returns (GetConversationsResponse);
     rpc GetConversation(GetConversationRequest)                   returns (ConversationResponse);
     rpc LeaveConversation(LeaveConversationRequest)               returns (LeaveConversationResponse);
+    rpc KickMember(KickMemberRequest)                             returns (KickMemberResponse);
+    rpc UpdateMemberRole(UpdateMemberRoleRequest)                 returns (UpdateMemberRoleResponse);
 
     // Messages
     rpc SendMessage(SendMessageRequest)   returns (SendMessageResponse);

--- a/docs/architecture/messaging-service.md
+++ b/docs/architecture/messaging-service.md
@@ -317,6 +317,51 @@ messaging-service
 
 ---
 
+#### `KickMember(KickMemberRequest) → KickMemberResponse`
+Администратор удаляет участника из группы (серверная часть — пометка + SSE-событие).
+
+**Вход:**
+- `user_id` UUID — вызывающий (admin/owner)
+- `conversation_id` UUID
+- `target_user_id` UUID — удаляемый участник
+
+**Логика:**
+1. Проверка, что вызывающий — active member с ролью `owner` или `admin`
+2. Проверка, что `target_user_id != user_id` (для выхода — используй `LeaveConversation`)
+3. Проверка, что target — active member
+4. Нельзя кикнуть `owner`
+5. Admin может кикнуть только `member`; `owner` может кикнуть и `admin`, и `member`
+6. UPDATE `conversation_members.left_at = now()` для target
+7. Redis PUBLISH событие `member_kicked: { user_id, kicked_by }`
+
+**Возврат:** `success: bool`
+
+> **MLS Remove Commit:** После успешного kick серверная часть только помечает участника как ушедшего. Админ-клиент, получив успешный ответ, создаёт MLS Remove Commit через `removeMemberByIdentity()` и отправляет через `CommitGroupChange`. Это аналогично тому, как другие участники создают Remove Commit при `member_left`.
+
+---
+
+#### `UpdateMemberRole(UpdateMemberRoleRequest) → UpdateMemberRoleResponse`
+Изменение роли участника группы (promote/demote).
+
+**Вход:**
+- `user_id` UUID — вызывающий (admin/owner)
+- `conversation_id` UUID
+- `target_user_id` UUID
+- `new_role` string — `"admin"` или `"member"`
+
+**Логика:**
+1. Валидация `new_role` ∈ {`admin`, `member`}
+2. Проверка, что вызывающий — active member с ролью `owner` или `admin`
+3. Нельзя менять собственную роль
+4. Нельзя менять роль `owner`
+5. Только `owner` может снять `admin` → `member` (демоушн)
+6. UPDATE `conversation_members.role = new_role`
+7. Redis PUBLISH событие `role_changed: { user_id, new_role }`
+
+**Возврат:** `success: bool`
+
+---
+
 ### Сообщения
 
 #### `SendMessage(SendMessageRequest) → SendMessageResponse`


### PR DESCRIPTION
### Локализация

**Полная локализация приложения на два языка: English / Русский с мгновенным переключением без перезапуска(на регистрации).**

- Создан `AppStrings.kt` — интерфейс с ~250 строковыми свойствами/функциями, два объекта-реализации: `RuStrings`, `EnStrings`
- Реактивное переключение через `CompositionLocalProvider` + `LanguageViewModel` (хранит язык в `Settings`, ключ `"app_language"`)
- Для `@Composable` — `LocalStrings.current`, для ViewModel/утилит — `S.current`
- Дефолтный язык: **English**
- Убран snackbar "Перезапустите приложение" из `LanguageScreen` — язык меняется мгновенно
- Добавлен флаг-переключатель языка на `AuthScreen` (кнопка с флагом в правом верхнем углу + DropdownMenu)

**Затронутые файлы (22 шт.):**

`App.kt`, `AuthScreen.kt`, `ChatsScreen.kt`, `ContactsScreen.kt`, `ProfileScreen.kt`, `UserProfileScreen.kt`, `CreateGroupScreen.kt`, `GroupProfileScreen.kt`, `PrivacyViewModel.kt`, `PrivacyScreen.kt`, `NotificationsViewModel.kt`, `NotificationsScreen.kt`, `AppearanceScreen.kt`, `StorageScreen.kt`, `LanguageScreen.kt`, `LinkedDevicesScreen.kt`, `AddDeviceScreen.kt`, `BlackListScreen.kt`, `DateScrubber.kt`, `ChatViewModel.kt`, `ChatScreen.kt`, `SessionManager.kt`

**Новый файл:** `localization/AppStrings.kt`

---

### Исправление MLS Epoch Conflict (DM-чаты)

**Проблема:** При создании DM-беседы сервер внутренне инкрементирует epoch (для двух участников: creator + recipient), но `getPendingCommits` не отражает этот внутренний epoch. В результате клиент отправлял `epoch=1`, а сервер ожидал `epoch=2` — ошибка `"Epoch conflict — expected 2, got 1"`.

**Решение:** Добавлен хелпер `commitGroupChangeWithRetry()` в `ContactsViewModel.kt`:
- Отправляет commit с расчётным epoch
- При ошибке парсит `"expected N"` из сообщения через regex
- Если ожидаемый epoch выше — повторяет commit с правильным значением
- Возвращает фактический epoch для корректной работы последующих итераций

Удалён нерабочий подход через `getPendingCommits(sinceEpoch=0)` из трёх методов: `startDirectChatWith`, `startDirectChatByUserId`, `createGroupChat`.

**Затронутый файл:** `ContactsViewModel.kt`

---

### Прочие изменения

- Расширен `ConversationService` (добавление/удаление участников группы, переименование)
- Улучшения в `ChatScreen` (голосовые сообщения, аудио-плеер, UI)
- `ChatViewModel` — расширен функционал (удаление сообщений, обработка медиа)
- `ChatsViewModel` — обработка удаления участника из группы
- Обновлены аудио-интерфейсы (`AudioInterfaces.kt`, платформенные реализации)
- Добавлены "reply" на сообщения в чатах + копирование их и сохранение фото в галерею