### PR TITLE
some changes, like dark theme, color/img picker(with crop), etc

### DIFF
--- a/android-ios-app/composeApp/src/androidMain/kotlin/com/example/memegram/ImageUtils.android.kt
+++ b/android-ios-app/composeApp/src/androidMain/kotlin/com/example/memegram/ImageUtils.android.kt
@@ -1,8 +1,22 @@
 package com.example.memegram
 
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import java.io.ByteArrayOutputStream
 
 actual fun ByteArray.decodeToImageBitmap(): ImageBitmap =
     BitmapFactory.decodeByteArray(this, 0, size).asImageBitmap()
+
+actual fun ByteArray.cropImage(x: Int, y: Int, width: Int, height: Int): ByteArray {
+    val original = BitmapFactory.decodeByteArray(this, 0, size)
+    val cx = x.coerceIn(0, original.width - 1)
+    val cy = y.coerceIn(0, original.height - 1)
+    val cw = width.coerceAtMost(original.width - cx)
+    val ch = height.coerceAtMost(original.height - cy)
+    val cropped = Bitmap.createBitmap(original, cx, cy, cw, ch)
+    val stream = ByteArrayOutputStream()
+    cropped.compress(Bitmap.CompressFormat.JPEG, 90, stream)
+    return stream.toByteArray()
+}

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AddDeviceScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AddDeviceScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import org.koin.compose.viewmodel.koinViewModel
 import com.example.memegram.localization.LocalStrings
+import com.example.memegram.utils.sdp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -52,7 +53,7 @@ fun AddDeviceScreen(
             Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .padding(24.dp),
+                .padding(24.sdp),
             contentAlignment = Alignment.Center
         ) {
             when (step) {
@@ -63,13 +64,13 @@ fun AddDeviceScreen(
                             style = MaterialTheme.typography.titleMedium,
                             textAlign = TextAlign.Center
                         )
-                        Spacer(Modifier.height(24.dp))
+                        Spacer(Modifier.height(24.sdp))
 
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .aspectRatio(1f)
-                                .clip(androidx.compose.foundation.shape.RoundedCornerShape(24.dp))
+                                .clip(androidx.compose.foundation.shape.RoundedCornerShape(24.sdp))
                                 .background(MaterialTheme.colorScheme.surfaceVariant),
                             contentAlignment = Alignment.Center
                         ) {
@@ -79,14 +80,14 @@ fun AddDeviceScreen(
                             )
                         }
 
-                        Spacer(Modifier.height(16.dp))
+                        Spacer(Modifier.height(16.sdp))
                         Text(
                             s.pasteCodeHint,
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             textAlign = TextAlign.Center
                         )
-                        Spacer(Modifier.height(8.dp))
+                        Spacer(Modifier.height(8.sdp))
 
                         Row(
                             modifier = Modifier.fillMaxWidth(),
@@ -101,7 +102,7 @@ fun AddDeviceScreen(
                                 singleLine = false,
                                 maxLines = 3
                             )
-                            Spacer(Modifier.width(4.dp))
+                            Spacer(Modifier.width(4.sdp))
                             IconButton(
                                 onClick = {
                                     clipboardManager.getText()?.text?.let {
@@ -117,7 +118,7 @@ fun AddDeviceScreen(
                             }
                         }
 
-                        Spacer(Modifier.height(12.dp))
+                        Spacer(Modifier.height(12.sdp))
                         Button(
                             onClick = { vm.onQrScanned(manualInput) },
                             enabled = manualInput.isNotBlank(),
@@ -131,7 +132,7 @@ fun AddDeviceScreen(
                 AddDeviceStep.SUBMITTING -> {
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                        verticalArrangement = Arrangement.spacedBy(16.sdp)
                     ) {
                         CircularProgressIndicator()
                         Text(s.sendingDeviceData)
@@ -141,7 +142,7 @@ fun AddDeviceScreen(
                 AddDeviceStep.WAITING_APPROVAL -> {
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                        verticalArrangement = Arrangement.spacedBy(16.sdp)
                     ) {
                         CircularProgressIndicator()
                         Text(
@@ -161,13 +162,13 @@ fun AddDeviceScreen(
                 AddDeviceStep.CONFIRMED -> {
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                        verticalArrangement = Arrangement.spacedBy(12.sdp)
                     ) {
                         Icon(
                             Icons.Default.CheckCircle,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(64.dp)
+                            modifier = Modifier.size(64.sdp)
                         )
                         Text(s.deviceAdded, style = MaterialTheme.typography.titleMedium)
                     }
@@ -176,13 +177,13 @@ fun AddDeviceScreen(
                 AddDeviceStep.REJECTED, AddDeviceStep.ERROR -> {
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                        verticalArrangement = Arrangement.spacedBy(12.sdp)
                     ) {
                         Icon(
                             Icons.Default.Error,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.error,
-                            modifier = Modifier.size(64.dp)
+                            modifier = Modifier.size(64.sdp)
                         )
                         Text(
                             error ?: s.errorOccurred,

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/App.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/App.kt
@@ -1,19 +1,28 @@
 package com.example.memegram
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.foundation.layout.Box
+import com.example.memegram.utils.LocalScreenWidthDp
+import com.example.memegram.utils.LocalScreenHeightDp
+import com.example.memegram.utils.LocalTopBarImage
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -49,6 +58,50 @@ import org.koin.dsl.koinConfiguration
 @Serializable data class UserProfileRoute(val userId: String, val username: String)
 @Serializable data class GroupProfileRoute(val conversationId: String, val groupName: String)
 
+// ── Light color scheme ───────────────────────────────────────────────
+private val LightColors = lightColorScheme(
+    primary = Color(0xFF6075F2),
+    onPrimary = Color.White,
+    primaryContainer = Color(0xFFDEE0FF),
+    onPrimaryContainer = Color(0xFF001258),
+    secondary = Color(0xFF5B5D72),
+    onSecondary = Color.White,
+    secondaryContainer = Color(0xFFE0E1F9),
+    onSecondaryContainer = Color(0xFF181A2C),
+    tertiary = Color(0xFF77536D),
+    onTertiary = Color.White,
+    background = Color(0xFFFFFBFF),
+    onBackground = Color(0xFF1B1B1F),
+    surface = Color(0xFFFFFBFF),
+    onSurface = Color(0xFF1B1B1F),
+    surfaceVariant = Color(0xFFE3E1EC),
+    onSurfaceVariant = Color(0xFF46464F),
+    outline = Color(0xFF767680),
+    outlineVariant = Color(0xFFC7C5D0),
+)
+
+// ── Dark color scheme ────────────────────────────────────────────────
+private val DarkColors = darkColorScheme(
+    primary = Color(0xFFBBC3FF),
+    onPrimary = Color(0xFF08218A),
+    primaryContainer = Color(0xFF4559D9),
+    onPrimaryContainer = Color(0xFFDEE0FF),
+    secondary = Color(0xFFC4C5DD),
+    onSecondary = Color(0xFF2D2F42),
+    secondaryContainer = Color(0xFF434559),
+    onSecondaryContainer = Color(0xFFE0E1F9),
+    tertiary = Color(0xFFE6B9D8),
+    onTertiary = Color(0xFF44263D),
+    background = Color(0xFF1B1B1F),
+    onBackground = Color(0xFFE4E1E6),
+    surface = Color(0xFF1B1B1F),
+    onSurface = Color(0xFFE4E1E6),
+    surfaceVariant = Color(0xFF46464F),
+    onSurfaceVariant = Color(0xFFC7C5D0),
+    outline = Color(0xFF90909A),
+    outlineVariant = Color(0xFF46464F),
+)
+
 @Composable
 fun App() {
     LaunchedEffect(Unit) {
@@ -59,14 +112,31 @@ fun App() {
     }) {
         val themeViewModel = koinViewModel<ThemeViewModel>()
         val topBarColor by themeViewModel.topBarColor.collectAsState()
+        val topBarImageBytes by themeViewModel.topBarImage.collectAsState()
+        val isDarkMode by themeViewModel.isDarkMode.collectAsState()
+
+        val topBarBitmap = remember(topBarImageBytes) {
+            topBarImageBytes?.let { runCatching { it.decodeToImageBitmap() }.getOrNull() }
+        }
 
         val languageViewModel = koinViewModel<LanguageViewModel>()
         val currentLang by languageViewModel.currentLang.collectAsState()
         val strings = if (currentLang == "ru") RuStrings else EnStrings
         LaunchedEffect(strings) { S.current = strings }
 
+        val colorScheme = if (isDarkMode) DarkColors else LightColors
+
         CompositionLocalProvider(LocalStrings provides strings) {
-        MaterialTheme {
+        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+            val density = LocalDensity.current
+            val screenWidthDp = with(density) { constraints.maxWidth.toDp() }.value
+            val screenHeightDp = with(density) { constraints.maxHeight.toDp() }.value
+            CompositionLocalProvider(
+                LocalScreenWidthDp provides screenWidthDp,
+                LocalScreenHeightDp provides screenHeightDp,
+                LocalTopBarImage provides topBarBitmap
+            ) {
+        MaterialTheme(colorScheme = colorScheme) {
             Surface {
                 val navController = rememberNavController()
                 val navBackStackEntry by navController.currentBackStackEntryFlow.collectAsState(null)
@@ -88,7 +158,8 @@ fun App() {
                                 navController.navigate(AddDeviceRoute)
                             },
                             viewModel = viewModel,
-                            languageViewModel = languageViewModel
+                            languageViewModel = languageViewModel,
+                            themeViewModel = themeViewModel
                         )
                     }
                     composable<ChatsRoute> {
@@ -102,7 +173,7 @@ fun App() {
                                         chatName = chat.name,
                                         conversationId = chat.conversationId
                                     )
-                                )
+                                ) { launchSingleTop = true }
                             },
                             onNavigateToChat = { convId ->
                                 navController.navigate(
@@ -110,20 +181,20 @@ fun App() {
                                         chatName = strings.newChat,
                                         conversationId = convId
                                     )
-                                )
+                                ) { launchSingleTop = true }
                             },
                             onNavigateToCreateGroup = {
-                                navController.navigate(CreateGroupRoute)
+                                navController.navigate(CreateGroupRoute) { launchSingleTop = true }
                             },
-                            onAppearanceClick = { navController.navigate(AppearanceRoute) },
-                            onProfileClick = { navController.navigate(ProfileRoute) },
-                            onNotificationsClick = { navController.navigate(NotificationsRoute) },
-                            onLanguageClick = { navController.navigate(LanguageRoute) },
-                            onPrivacyClick = { navController.navigate(PrivacyRoute) },
+                            onAppearanceClick = { navController.navigate(AppearanceRoute) { launchSingleTop = true } },
+                            onProfileClick = { navController.navigate(ProfileRoute) { launchSingleTop = true } },
+                            onNotificationsClick = { navController.navigate(NotificationsRoute) { launchSingleTop = true } },
+                            onLanguageClick = { navController.navigate(LanguageRoute) { launchSingleTop = true } },
+                            onPrivacyClick = { navController.navigate(PrivacyRoute) { launchSingleTop = true } },
                             profileViewModel = profileViewModel,
-                            onContactsClick = { navController.navigate(ContactsRoute) },
-                            onStorageClick = { navController.navigate(StorageRoute) },
-                            onLinkedDevicesClick = { navController.navigate(LinkedDevicesRoute) },
+                            onContactsClick = { navController.navigate(ContactsRoute) { launchSingleTop = true } },
+                            onStorageClick = { navController.navigate(StorageRoute) { launchSingleTop = true } },
+                            onLinkedDevicesClick = { navController.navigate(LinkedDevicesRoute) { launchSingleTop = true } },
                             viewModel = viewModel
                         )
                     }
@@ -149,11 +220,11 @@ fun App() {
                             onProfileClick = {
                                 val isGroup = viewModel.isGroupChat.value
                                 if (isGroup) {
-                                    navController.navigate(GroupProfileRoute(route.conversationId, route.chatName))
+                                    navController.navigate(GroupProfileRoute(route.conversationId, route.chatName)) { launchSingleTop = true }
                                 } else {
                                     val peerId = viewModel.peerUserId
                                     if (peerId != null) {
-                                        navController.navigate(UserProfileRoute(peerId, route.chatName))
+                                        navController.navigate(UserProfileRoute(peerId, route.chatName)) { launchSingleTop = true }
                                     }
                                 }
                             },
@@ -169,7 +240,8 @@ fun App() {
                                     navController.popBackStack()
                             },
                             onTopBarColorChanged = { themeViewModel.refreshTheme() },
-                            viewModel = viewModel
+                            viewModel = viewModel,
+                            themeViewModel = themeViewModel
                         )
                     }
                     composable<ProfileRoute> {
@@ -283,9 +355,10 @@ fun App() {
                     composable<CreateGroupRoute> {
                         CreateGroupScreen(
                             onBack = { navController.popBackStack() },
-                            onGroupCreated = { chatId ->
-                                navController.navigate(ChatDetailRoute(strings.groupDefault, chatId)) {
+                            onGroupCreated = { chatId, name ->
+                                navController.navigate(ChatDetailRoute(name, chatId)) {
                                     popUpTo(ChatsRoute)
+                                    launchSingleTop = true
                                 }
                             }
                         )
@@ -347,6 +420,8 @@ fun App() {
                 }
             }
         }
-        } // CompositionLocalProvider
+        } // CompositionLocalProvider (LocalScreenWidthDp)
+        } // BoxWithConstraints
+        } // CompositionLocalProvider (LocalStrings)
     }
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AppearanceScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AppearanceScreen.kt
@@ -1,26 +1,105 @@
 package com.example.memegram
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import com.example.memegram.localization.LocalStrings
+import io.github.vinceglb.filekit.compose.rememberFilePickerLauncher
+import io.github.vinceglb.filekit.core.PickerMode
+import io.github.vinceglb.filekit.core.PickerType
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
+import com.example.memegram.utils.ImageTopAppBarBox
+import com.example.memegram.utils.LocalScreenWidthDp
+import com.example.memegram.utils.LocalScreenHeightDp
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.statusBars
+
+// ── HSV utilities ────────────────────────────────────────────────────
+private data class HsvColor(val hue: Float, val saturation: Float, val value: Float) {
+    fun toColor(): Color {
+        val c = value * saturation
+        val x = c * (1f - kotlin.math.abs((hue / 60f) % 2f - 1f))
+        val m = value - c
+        val (r, g, b) = when {
+            hue < 60f  -> Triple(c, x, 0f)
+            hue < 120f -> Triple(x, c, 0f)
+            hue < 180f -> Triple(0f, c, x)
+            hue < 240f -> Triple(0f, x, c)
+            hue < 300f -> Triple(x, 0f, c)
+            else       -> Triple(c, 0f, x)
+        }
+        return Color(r + m, g + m, b + m, 1f)
+    }
+
+    companion object {
+        fun fromColor(color: Color): HsvColor {
+            val r = color.red; val g = color.green; val b = color.blue
+            val max = maxOf(r, g, b); val min = minOf(r, g, b); val delta = max - min
+            val hue = when {
+                delta == 0f -> 0f
+                max == r -> 60f * (((g - b) / delta) % 6f)
+                max == g -> 60f * (((b - r) / delta) + 2f)
+                else -> 60f * (((r - g) / delta) + 4f)
+            }.let { if (it < 0f) it + 360f else it }
+            val saturation = if (max == 0f) 0f else delta / max
+            return HsvColor(hue, saturation, max)
+        }
+    }
+}
+
+private fun Color.toHexString(): String {
+    val argb = this.toArgb()
+    return String.format("%06X", argb and 0xFFFFFF)
+}
+
+private fun hexToColor(hex: String): Color? {
+    val clean = hex.removePrefix("#").trim()
+    if (clean.length != 6) return null
+    return try { Color(clean.toLong(16).toInt() or (0xFF shl 24)) } catch (_: Exception) { null }
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -28,131 +107,324 @@ fun AppearanceScreen(
     topBarColor: Color,
     onBack: () -> Unit,
     onTopBarColorChanged: () -> Unit,
-    viewModel: AppearanceViewModel
+    viewModel: AppearanceViewModel,
+    themeViewModel: ThemeViewModel
 ) {
     val s = LocalStrings.current
     val chatBgColor by viewModel.chatBgColor.collectAsState()
     val myBubbleColor by viewModel.myBubbleColor.collectAsState()
     val theirBubbleColor by viewModel.theirBubbleColor.collectAsState()
+    val isDarkMode by themeViewModel.isDarkMode.collectAsState()
+
+    val chatBgImage by viewModel.chatBgImage.collectAsState()
+    val topBarImage by viewModel.topBarImage.collectAsState()
+    val myBubbleImage by viewModel.myBubbleImage.collectAsState()
+    val theirBubbleImage by viewModel.theirBubbleImage.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
 
     var showColorPickerForKey by remember { mutableStateOf<String?>(null) }
     val topBarTextColor = if (topBarColor.luminance() > 0.5f) Color.Black else Color.White
+    val scope = rememberCoroutineScope()
+
+    var cropBytes by remember { mutableStateOf<ByteArray?>(null) }
+    var cropKey by remember { mutableStateOf<String?>(null) }
+
+    val chatBgPicker = rememberFilePickerLauncher(PickerType.Image, PickerMode.Single) { f ->
+        f?.let { scope.launch { cropBytes = it.readBytes(); cropKey = "chatbg" } }
+    }
+    val topBarPicker = rememberFilePickerLauncher(PickerType.Image, PickerMode.Single) { f ->
+        f?.let { scope.launch { cropBytes = it.readBytes(); cropKey = "topbar" } }
+    }
+    val myBubblePicker = rememberFilePickerLauncher(PickerType.Image, PickerMode.Single) { f ->
+        f?.let { scope.launch { cropBytes = it.readBytes(); cropKey = "mybubble" } }
+    }
+    val theirBubblePicker = rememberFilePickerLauncher(PickerType.Image, PickerMode.Single) { f ->
+        f?.let { scope.launch { cropBytes = it.readBytes(); cropKey = "theirbubble" } }
+    }
+
+    val screenWidthDp = LocalScreenWidthDp.current
+    val screenHeightDp = LocalScreenHeightDp.current
+
+    val density = LocalDensity.current
+    val statusBarDp = with(density) { WindowInsets.statusBars.getTop(density).toDp().value }
+    val topBarTotalHeight = 64f + statusBarDp
+
+    if (cropBytes != null && cropKey != null) {
+        val ratio = when (cropKey!!) {
+            "topbar" -> screenWidthDp / topBarTotalHeight
+            "chatbg" -> screenWidthDp / (screenHeightDp - 144f)
+            else -> 0f
+        }
+        ImageCropScreen(
+            imageBytes = cropBytes!!,
+            aspectRatio = ratio,
+            onCropped = { croppedBytes ->
+                viewModel.updateImage(cropKey!!, croppedBytes)
+                if (cropKey == "topbar") onTopBarColorChanged()
+                cropBytes = null; cropKey = null
+            },
+            onCancel = { cropBytes = null; cropKey = null }
+        )
+        return
+    }
 
     Scaffold(
         topBar = {
+            ImageTopAppBarBox(topBarColor) { bgColor ->
             TopAppBar(
                 title = { Text(s.appearanceTitle) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = null,
-                            tint = topBarTextColor
-                        )
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = topBarTextColor)
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = topBarColor,
+                    containerColor = bgColor,
                     titleContentColor = topBarTextColor,
                     navigationIconContentColor = topBarTextColor
                 )
             )
+            }
         }
     ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-        ) {
-            Text(
-                text = s.preview,
-                modifier = Modifier.padding(16.dp),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
-            )
-
-            Box(
+        Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .height(220.dp)
-                    .padding(horizontal = 16.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(chatBgColor)
-                    .border(1.dp, Color.LightGray, RoundedCornerShape(12.dp))
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
             ) {
-                Column(modifier = Modifier.fillMaxSize()) {
-                    val previewTopBarTextColor = if (topBarColor.luminance() > 0.5f) Color.Black else Color.White
-                    Surface(
-                        color = topBarColor,
-                        modifier = Modifier.fillMaxWidth().height(50.dp)
+                // ── Theme toggle ─────────────────────────────────────
+                Text(
+                    text = s.themeSection,
+                    modifier = Modifier.padding(start = 16.sdp, top = 16.sdp, bottom = 8.sdp),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.sdp)
+                        .clip(RoundedCornerShape(16.sdp))
+                        .clickable { themeViewModel.toggleDarkMode() },
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                    shape = RoundedCornerShape(16.sdp)
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 20.sdp, vertical = 16.sdp),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Box(contentAlignment = Alignment.CenterStart, modifier = Modifier.padding(horizontal = 16.dp)) {
-                            Text(s.chatPreview, color = previewTopBarTextColor, fontWeight = FontWeight.Bold)
+                        AnimatedContent(
+                            targetState = isDarkMode,
+                            transitionSpec = { (fadeIn() + scaleIn()) togetherWith (fadeOut() + scaleOut()) }
+                        ) { dark ->
+                            Icon(
+                                imageVector = if (dark) Icons.Default.DarkMode else Icons.Default.LightMode,
+                                contentDescription = null,
+                                tint = if (dark) Color(0xFFFFC107) else Color(0xFFFF9800),
+                                modifier = Modifier.size(26.sdp)
+                            )
                         }
+                        Spacer(Modifier.width(16.sdp))
+                        Text(s.darkTheme, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
+                        Spacer(Modifier.weight(1f))
+                        Switch(
+                            checked = isDarkMode,
+                            onCheckedChange = { themeViewModel.setDarkMode(it) },
+                            colors = SwitchDefaults.colors(checkedThumbColor = Color.White, checkedTrackColor = Color(0xFF6075F2))
+                        )
                     }
+                }
 
-                    Spacer(modifier = Modifier.height(16.dp))
+                Spacer(Modifier.height(16.sdp))
 
-                    val theirTextColor = if (theirBubbleColor.luminance() > 0.5f) Color.Black else Color.White
-                    Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp), contentAlignment = Alignment.CenterStart) {
-                        Box(modifier = Modifier.clip(RoundedCornerShape(16.dp, 16.dp, 16.dp, 4.dp)).background(theirBubbleColor).padding(12.dp)) {
-                            Text(s.previewMessage1, color = theirTextColor)
+                // ── Preview ──────────────────────────────────────────
+                Text(
+                    text = s.preview,
+                    modifier = Modifier.padding(start = 16.sdp, bottom = 8.sdp),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(280.sdp)
+                        .padding(horizontal = 16.sdp)
+                        .clip(RoundedCornerShape(12.sdp))
+                        .background(chatBgColor)
+                        .border(1.sdp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(12.sdp))
+                ) {
+                    if (chatBgImage != null) {
+                        val bmp = remember(chatBgImage) { chatBgImage?.let { runCatching { it.decodeToImageBitmap() }.getOrNull() } }
+                        bmp?.let { Image(bitmap = it, contentDescription = null, modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Crop) }
+                    }
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        val previewTopBarTextColor = if (topBarColor.luminance() > 0.5f) Color.Black else Color.White
+                        Box(modifier = Modifier.fillMaxWidth().aspectRatio(screenWidthDp / topBarTotalHeight)) {
+                            val topBarBmp = remember(topBarImage) { topBarImage?.let { runCatching { it.decodeToImageBitmap() }.getOrNull() } }
+                            if (topBarBmp != null) {
+                                Image(bitmap = topBarBmp, contentDescription = null, modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Crop)
+                            } else {
+                                Surface(color = topBarColor, modifier = Modifier.fillMaxSize()) {}
+                            }
+                            Box(contentAlignment = Alignment.CenterStart, modifier = Modifier.fillMaxSize().padding(horizontal = 16.sdp)) {
+                                Text(s.chatPreview, color = previewTopBarTextColor, fontWeight = FontWeight.Bold)
+                            }
                         }
-                    }
 
-                    Spacer(modifier = Modifier.height(8.dp))
+                        Spacer(modifier = Modifier.weight(1f))
 
-                    val myTextColor = if (myBubbleColor.luminance() > 0.5f) Color.Black else Color.White
-                    Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp), contentAlignment = Alignment.CenterEnd) {
-                        Box(modifier = Modifier.clip(RoundedCornerShape(16.dp, 16.dp, 4.dp, 16.dp)).background(myBubbleColor).padding(12.dp)) {
-                            Text(s.previewMessage2, color = myTextColor)
+                        // ── Bubble previews ──────────────────────────
+                        val theirBubbleBmp = remember(theirBubbleImage) { theirBubbleImage?.let { runCatching { it.decodeToImageBitmap() }.getOrNull() } }
+                        val myBubbleBmp = remember(myBubbleImage) { myBubbleImage?.let { runCatching { it.decodeToImageBitmap() }.getOrNull() } }
+
+                        val theirTextColor = if (theirBubbleBmp != null) Color.White
+                            else if (theirBubbleColor.luminance() > 0.5f) Color.Black else Color.White
+                        Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.sdp), contentAlignment = Alignment.CenterStart) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth(0.72f)
+                                    .clip(RoundedCornerShape(16.sdp, 16.sdp, 16.sdp, 4.sdp))
+                                    .background(theirBubbleColor)
+                            ) {
+                                if (theirBubbleBmp != null) {
+                                    Image(bitmap = theirBubbleBmp, contentDescription = null, modifier = Modifier.matchParentSize(), contentScale = ContentScale.Crop)
+                                }
+                                Text(s.previewMessage1, color = theirTextColor, modifier = Modifier.padding(horizontal = 14.sdp, vertical = 10.sdp))
+                            }
                         }
+
+                        Spacer(modifier = Modifier.height(8.sdp))
+
+                        val myTextColor = if (myBubbleBmp != null) Color.White
+                            else if (myBubbleColor.luminance() > 0.5f) Color.Black else Color.White
+                        Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.sdp), contentAlignment = Alignment.CenterEnd) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth(0.72f)
+                                    .clip(RoundedCornerShape(16.sdp, 16.sdp, 4.sdp, 16.sdp))
+                                    .background(myBubbleColor)
+                            ) {
+                                if (myBubbleBmp != null) {
+                                    Image(bitmap = myBubbleBmp, contentDescription = null, modifier = Modifier.matchParentSize(), contentScale = ContentScale.Crop)
+                                }
+                                Text(s.previewMessage2, color = myTextColor, modifier = Modifier.padding(horizontal = 14.sdp, vertical = 10.sdp))
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(16.sdp))
                     }
+                }
+
+                HorizontalDivider(modifier = Modifier.padding(vertical = 16.sdp))
+
+                // ── Color/Photo settings ─────────────────────────────
+                AppearanceSettingItem(
+                    title = s.topBarColor,
+                    currentColor = topBarColor,
+                    hasImage = topBarImage != null,
+                    onColorClick = { showColorPickerForKey = "topbar" },
+                    onPhotoClick = { topBarPicker.launch() }
+                )
+                AppearanceSettingItem(
+                    title = s.chatBgColor,
+                    currentColor = chatBgColor,
+                    hasImage = chatBgImage != null,
+                    onColorClick = { showColorPickerForKey = "chatbg" },
+                    onPhotoClick = { chatBgPicker.launch() }
+                )
+                AppearanceSettingItem(
+                    title = s.myMessageColor,
+                    currentColor = myBubbleColor,
+                    hasImage = myBubbleImage != null,
+                    onColorClick = { showColorPickerForKey = "mybubble" },
+                    onPhotoClick = { myBubblePicker.launch() }
+                )
+                AppearanceSettingItem(
+                    title = s.otherMessageColor,
+                    currentColor = theirBubbleColor,
+                    hasImage = theirBubbleImage != null,
+                    onColorClick = { showColorPickerForKey = "theirbubble" },
+                    onPhotoClick = { theirBubblePicker.launch() }
+                )
+
+                Spacer(Modifier.height(24.sdp))
+
+                if (showColorPickerForKey != null) {
+                    val currentColor = when (showColorPickerForKey) {
+                        "topbar" -> topBarColor
+                        "chatbg" -> chatBgColor
+                        "mybubble" -> myBubbleColor
+                        "theirbubble" -> theirBubbleColor
+                        else -> Color.White
+                    }
+                    ColorPickerDialog(
+                        title = s.chooseColor,
+                        cancelLabel = s.cancel,
+                        selectLabel = s.selectColor,
+                        presetsLabel = s.colorPickerPresets,
+                        customLabel = s.colorPickerCustom,
+                        hexLabel = s.colorPickerHex,
+                        initialColor = currentColor,
+                        onColorSelected = { color ->
+                            viewModel.updateColor(showColorPickerForKey!!, color)
+                            if (showColorPickerForKey == "topbar") onTopBarColorChanged()
+                            showColorPickerForKey = null
+                        },
+                        onDismiss = { showColorPickerForKey = null }
+                    )
                 }
             }
 
-            HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
-
-            SettingItem(s.topBarColor, topBarColor) { showColorPickerForKey = "topbar" }
-            SettingItem(s.chatBgColor, chatBgColor) { showColorPickerForKey = "chatbg" }
-            SettingItem(s.myMessageColor, myBubbleColor) { showColorPickerForKey = "mybubble" }
-            SettingItem(s.otherMessageColor, theirBubbleColor) { showColorPickerForKey = "theirbubble" }
-
-            if (showColorPickerForKey != null) {
-                ColorPickerDialog(
-                    title = s.chooseColor,
-                    cancelLabel = s.cancel,
-                    onColorSelected = { color ->
-                        viewModel.updateColor(showColorPickerForKey!!, color)
-                        if (showColorPickerForKey == "topbar") {
-                            onTopBarColorChanged()
-                        }
-                        showColorPickerForKey = null
-                    },
-                    onDismiss = { showColorPickerForKey = null }
-                )
+            if (isLoading) {
+                Box(
+                    modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.3f)),
+                    contentAlignment = Alignment.Center
+                ) { CircularProgressIndicator(color = Color.White) }
             }
         }
     }
 }
 
 @Composable
-fun SettingItem(title: String, currentColor: Color, onClick: () -> Unit) {
+private fun AppearanceSettingItem(
+    title: String,
+    currentColor: Color,
+    hasImage: Boolean,
+    onColorClick: () -> Unit,
+    onPhotoClick: () -> Unit
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(16.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
+            .clickable(onClick = onColorClick)
+            .padding(horizontal = 16.sdp, vertical = 12.sdp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(text = title, style = MaterialTheme.typography.titleMedium)
+        Text(text = title, style = MaterialTheme.typography.titleMedium, modifier = Modifier.weight(1f))
+        Surface(
+            modifier = Modifier
+                .size(36.sdp)
+                .clip(CircleShape)
+                .clickable(onClick = onPhotoClick),
+            shape = CircleShape,
+            color = if (hasImage) Color(0xFF6075F2) else MaterialTheme.colorScheme.surfaceVariant
+        ) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                Icon(
+                    Icons.Default.CameraAlt,
+                    contentDescription = null,
+                    tint = if (hasImage) Color.White else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.sdp)
+                )
+            }
+        }
+        Spacer(Modifier.width(10.sdp))
         Box(
             modifier = Modifier
-                .size(36.dp)
+                .size(36.sdp)
                 .clip(CircleShape)
                 .background(currentColor)
-                .border(1.dp, Color.Gray, CircleShape)
+                .border(1.sdp, MaterialTheme.colorScheme.outline, CircleShape)
         )
     }
 }
@@ -161,37 +433,153 @@ fun SettingItem(title: String, currentColor: Color, onClick: () -> Unit) {
 fun ColorPickerDialog(
     title: String,
     cancelLabel: String,
+    selectLabel: String,
+    presetsLabel: String,
+    customLabel: String,
+    hexLabel: String,
+    initialColor: Color,
     onColorSelected: (Color) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val colors = listOf(
+    val presetColors = listOf(
         Color(0xFF6075F2), Color(0xFFF5F5F5), Color(0xFFD1C4E9), Color(0xFFFFFFFF),
         Color(0xFFFF5252), Color(0xFFFF4081), Color(0xFFE040FB), Color(0xFF7C4DFF),
         Color(0xFF536DFE), Color(0xFF448AFF), Color(0xFF40C4FF), Color(0xFF18FFFF),
         Color(0xFF64FFDA), Color(0xFF69F0AE), Color(0xFFB2FF59), Color(0xFFEEFF41),
-        Color(0xFF212121), Color(0xFFFFD740), Color(0xFFFFAB40), Color(0xFFFF6E40)
+        Color(0xFF212121), Color(0xFFFFD740), Color(0xFFFFAB40), Color(0xFFFF6E40),
+        Color(0xFF795548), Color(0xFF455A64), Color(0xFFE0E0E0), Color(0xFF9E9E9E),
     )
+
+    var hsv by remember { mutableStateOf(HsvColor.fromColor(initialColor)) }
+    var hexInput by remember { mutableStateOf(initialColor.toHexString()) }
+    var showCustomPicker by remember { mutableStateOf(false) }
+    val selectedColor = hsv.toColor()
+
+    LaunchedEffect(hsv) { hexInput = hsv.toColor().toHexString() }
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(title) },
+        title = {
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                Text(title, modifier = Modifier.weight(1f))
+                Box(
+                    modifier = Modifier.size(32.sdp).clip(CircleShape)
+                        .background(selectedColor).border(2.sdp, MaterialTheme.colorScheme.outline, CircleShape)
+                )
+            }
+        },
         text = {
-            LazyVerticalGrid(columns = GridCells.Fixed(4), modifier = Modifier.height(250.dp)) {
-                items(colors) { color ->
-                    Box(
-                        modifier = Modifier
-                            .padding(8.dp)
-                            .size(40.dp)
-                            .clip(CircleShape)
-                            .background(color)
-                            .border(1.dp, Color.LightGray, CircleShape)
-                            .clickable { onColorSelected(color) }
-                    )
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.sdp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    horizontalArrangement = Arrangement.SpaceEvenly
+                ) {
+                    TabButton(presetsLabel, !showCustomPicker) { showCustomPicker = false }
+                    TabButton(customLabel, showCustomPicker) { showCustomPicker = true }
+                }
+                Spacer(Modifier.height(16.sdp))
+                if (!showCustomPicker) {
+                    LazyVerticalGrid(
+                        columns = GridCells.Fixed(6),
+                        modifier = Modifier.fillMaxWidth().height(220.sdp)
+                    ) {
+                        items(presetColors) { color ->
+                            val isSelected = color.toArgb() == selectedColor.toArgb()
+                            Box(
+                                modifier = Modifier.padding(6.sdp).size(36.sdp).clip(CircleShape)
+                                    .background(color)
+                                    .then(if (isSelected) Modifier.border(3.sdp, Color(0xFF6075F2), CircleShape)
+                                    else Modifier.border(1.sdp, MaterialTheme.colorScheme.outlineVariant, CircleShape))
+                                    .clickable { hsv = HsvColor.fromColor(color) }
+                            )
+                        }
+                    }
+                } else {
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        SaturationValuePanel(
+                            hue = hsv.hue, saturation = hsv.saturation, value = hsv.value,
+                            onSatValChanged = { s, v -> hsv = hsv.copy(saturation = s, value = v) },
+                            modifier = Modifier.fillMaxWidth().height(180.sdp).clip(RoundedCornerShape(8.sdp))
+                        )
+                        Spacer(Modifier.height(12.sdp))
+                        HueBar(
+                            hue = hsv.hue, onHueChanged = { h -> hsv = hsv.copy(hue = h) },
+                            modifier = Modifier.fillMaxWidth().height(32.sdp).clip(RoundedCornerShape(8.sdp))
+                        )
+                        Spacer(Modifier.height(16.sdp))
+                        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                            Text("#", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, modifier = Modifier.padding(end = 4.sdp))
+                            OutlinedTextField(
+                                value = hexInput,
+                                onValueChange = { newHex ->
+                                    if (newHex.length <= 6) {
+                                        hexInput = newHex.uppercase().filter { it in '0'..'9' || it in 'A'..'F' }
+                                        if (hexInput.length == 6) hexToColor(hexInput)?.let { c -> hsv = HsvColor.fromColor(c) }
+                                    }
+                                },
+                                modifier = Modifier.weight(1f).height(52.sdp),
+                                singleLine = true, shape = RoundedCornerShape(8.sdp),
+                                textStyle = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                                label = { Text(hexLabel, fontSize = 11.ssp) }
+                            )
+                            Spacer(Modifier.width(12.sdp))
+                            Box(
+                                modifier = Modifier.size(44.sdp).clip(RoundedCornerShape(8.sdp))
+                                    .background(selectedColor).border(2.sdp, MaterialTheme.colorScheme.outline, RoundedCornerShape(8.sdp))
+                            )
+                        }
+                    }
                 }
             }
         },
-        confirmButton = {
-            TextButton(onClick = onDismiss) { Text(cancelLabel) }
-        }
+        confirmButton = { TextButton(onClick = { onColorSelected(selectedColor) }) { Text(selectLabel, fontWeight = FontWeight.Bold) } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(cancelLabel) } }
     )
+}
+
+@Composable
+private fun RowScope.TabButton(label: String, selected: Boolean, onClick: () -> Unit) {
+    val bgColor by animateColorAsState(if (selected) MaterialTheme.colorScheme.primary else Color.Transparent)
+    val textColor by animateColorAsState(if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant)
+    Box(
+        modifier = Modifier.weight(1f).clip(RoundedCornerShape(12.sdp)).background(bgColor)
+            .clickable(onClick = onClick).padding(vertical = 10.sdp),
+        contentAlignment = Alignment.Center
+    ) { Text(label, color = textColor, fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium, fontSize = 13.ssp) }
+}
+
+@Composable
+private fun SaturationValuePanel(hue: Float, saturation: Float, value: Float, onSatValChanged: (Float, Float) -> Unit, modifier: Modifier = Modifier) {
+    val hueColor = HsvColor(hue, 1f, 1f).toColor()
+    Box(modifier = modifier) {
+        Canvas(
+            modifier = Modifier.fillMaxSize()
+                .pointerInput(Unit) { detectTapGestures { off -> onSatValChanged((off.x / size.width).coerceIn(0f, 1f), 1f - (off.y / size.height).coerceIn(0f, 1f)) } }
+                .pointerInput(Unit) { detectDragGestures { ch, _ -> ch.consume(); onSatValChanged((ch.position.x / size.width).coerceIn(0f, 1f), 1f - (ch.position.y / size.height).coerceIn(0f, 1f)) } }
+        ) {
+            drawRect(Brush.horizontalGradient(listOf(Color.White, hueColor)), size = size)
+            drawRect(Brush.verticalGradient(listOf(Color.Transparent, Color.Black)), size = size)
+            val cx = saturation * size.width; val cy = (1f - value) * size.height
+            drawCircle(Color.White, 10f, Offset(cx, cy), style = Stroke(3f))
+            drawCircle(Color.Black, 12f, Offset(cx, cy), style = Stroke(1.5f))
+        }
+    }
+}
+
+@Composable
+private fun HueBar(hue: Float, onHueChanged: (Float) -> Unit, modifier: Modifier = Modifier) {
+    val rainbow = listOf(Color.Red, Color.Yellow, Color.Green, Color.Cyan, Color.Blue, Color.Magenta, Color.Red)
+    Box(modifier = modifier) {
+        Canvas(
+            modifier = Modifier.fillMaxSize()
+                .pointerInput(Unit) { detectTapGestures { off -> onHueChanged((off.x / size.width * 360f).coerceIn(0f, 360f)) } }
+                .pointerInput(Unit) { detectDragGestures { ch, _ -> ch.consume(); onHueChanged((ch.position.x / size.width * 360f).coerceIn(0f, 360f)) } }
+        ) {
+            drawRect(Brush.horizontalGradient(rainbow), size = size)
+            val px = hue / 360f * size.width
+            drawCircle(Color.White, size.height / 2f - 2f, Offset(px, size.height / 2f), style = Stroke(3f))
+            drawCircle(Color.Black, size.height / 2f, Offset(px, size.height / 2f), style = Stroke(1.5f))
+        }
+    }
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AppearanceViewModel.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AppearanceViewModel.kt
@@ -4,16 +4,24 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.memegram.data.models.InitiateItemUploadRequest
 import com.example.memegram.data.models.UpdateSettingsRequest
+import com.example.memegram.data.network.ApiService
 import com.example.memegram.data.repository.UserRepository
+import com.russhwolf.settings.Settings
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 
+@OptIn(ExperimentalEncodingApi::class)
 class AppearanceViewModel(
     private val themePreferences: ThemePreferences,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val api: ApiService,
+    private val settings: Settings
 ) : ViewModel() {
 
     private val _chatBgColor = MutableStateFlow(
@@ -31,10 +39,33 @@ class AppearanceViewModel(
     )
     val theirBubbleColor: StateFlow<Color> = _theirBubbleColor.asStateFlow()
 
+    private val _chatBgImage = MutableStateFlow<ByteArray?>(
+        settings.getStringOrNull("appearance_chatbg_image")?.let { runCatching { Base64.decode(it) }.getOrNull() }
+    )
+    val chatBgImage: StateFlow<ByteArray?> = _chatBgImage.asStateFlow()
+
+    private val _topBarImage = MutableStateFlow<ByteArray?>(
+        settings.getStringOrNull("appearance_topbar_image")?.let { runCatching { Base64.decode(it) }.getOrNull() }
+    )
+    val topBarImage: StateFlow<ByteArray?> = _topBarImage.asStateFlow()
+
+    private val _myBubbleImage = MutableStateFlow<ByteArray?>(
+        settings.getStringOrNull("appearance_mybubble_image")?.let { runCatching { Base64.decode(it) }.getOrNull() }
+    )
+    val myBubbleImage: StateFlow<ByteArray?> = _myBubbleImage.asStateFlow()
+
+    private val _theirBubbleImage = MutableStateFlow<ByteArray?>(
+        settings.getStringOrNull("appearance_theirbubble_image")?.let { runCatching { Base64.decode(it) }.getOrNull() }
+    )
+    val theirBubbleImage: StateFlow<ByteArray?> = _theirBubbleImage.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
     init {
         viewModelScope.launch {
-            userRepository.loadSettings().onSuccess { settings ->
-                settings.topBarColor?.let { hex ->
+            userRepository.loadSettings().onSuccess { s ->
+                s.topBarColor?.let { hex ->
                     runCatching {
                         val colorInt = hex.removePrefix("#").toLong(16).toInt()
                         themePreferences.saveColor("topbar", Color(colorInt or 0xFF000000.toInt()))
@@ -47,10 +78,91 @@ class AppearanceViewModel(
     fun updateColor(key: String, color: Color) {
         themePreferences.saveColor(key, color)
         when (key) {
-            "chatbg"      -> _chatBgColor.value = color
-            "mybubble"    -> _myBubbleColor.value = color
-            "theirbubble" -> _theirBubbleColor.value = color
-            "topbar"      -> syncTopBarToServer(color)
+            "chatbg" -> {
+                _chatBgColor.value = color
+                clearImageLocal("chatbg")
+                syncClearMediaToServer("chat_background_media_id")
+            }
+            "mybubble" -> {
+                _myBubbleColor.value = color
+                clearImageLocal("mybubble")
+                syncClearMediaToServer("my_bubble_media_id")
+            }
+            "theirbubble" -> {
+                _theirBubbleColor.value = color
+                clearImageLocal("theirbubble")
+                syncClearMediaToServer("their_bubble_media_id")
+            }
+            "topbar" -> {
+                syncTopBarToServer(color)
+                clearImageLocal("topbar")
+                syncClearMediaToServer("top_bar_media_id")
+            }
+        }
+    }
+
+    fun updateImage(key: String, bytes: ByteArray) {
+        val itemType = when (key) {
+            "chatbg" -> "chat_background"
+            "topbar" -> "top_bar"
+            "mybubble" -> "my_bubble"
+            "theirbubble" -> "their_bubble"
+            else -> return
+        }
+
+        val localKey = "appearance_${key}_image"
+        settings.putString(localKey, Base64.encode(bytes))
+        when (key) {
+            "chatbg" -> _chatBgImage.value = bytes
+            "topbar" -> _topBarImage.value = bytes
+            "mybubble" -> _myBubbleImage.value = bytes
+            "theirbubble" -> _theirBubbleImage.value = bytes
+        }
+
+        viewModelScope.launch {
+            _isLoading.value = true
+            try {
+                val mediaId = uploadImageToItemStorage(bytes, itemType, "image/jpeg")
+                settings.putString("${localKey}_media_id", mediaId)
+
+                val request = when (key) {
+                    "chatbg" -> UpdateSettingsRequest(chatBackgroundMediaId = mediaId)
+                    "topbar" -> UpdateSettingsRequest(topBarMediaId = mediaId)
+                    "mybubble" -> UpdateSettingsRequest(myBubbleMediaId = mediaId)
+                    "theirbubble" -> UpdateSettingsRequest(theirBubbleMediaId = mediaId)
+                    else -> null
+                }
+                request?.let { userRepository.updateSettings(it) }
+            } catch (e: Exception) {
+                println("AppearanceVM: Failed to upload image: ${e.message}")
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    private fun clearImageLocal(key: String) {
+        val localKey = "appearance_${key}_image"
+        settings.remove(localKey)
+        settings.remove("${localKey}_media_id")
+        when (key) {
+            "chatbg" -> _chatBgImage.value = null
+            "topbar" -> _topBarImage.value = null
+            "mybubble" -> _myBubbleImage.value = null
+            "theirbubble" -> _theirBubbleImage.value = null
+        }
+    }
+
+    private fun syncClearMediaToServer(fieldName: String) {
+        viewModelScope.launch {
+            val request = when (fieldName) {
+                "chat_background_media_id" -> UpdateSettingsRequest(chatBackgroundMediaId = "")
+                "top_bar_media_id" -> UpdateSettingsRequest(topBarMediaId = "")
+                "my_bubble_media_id" -> UpdateSettingsRequest(myBubbleMediaId = "")
+                "their_bubble_media_id" -> UpdateSettingsRequest(theirBubbleMediaId = "")
+                else -> null
+            }
+            request?.let { runCatching { userRepository.updateSettings(it) } }
         }
     }
 
@@ -59,5 +171,25 @@ class AppearanceViewModel(
             val hex = "#" + (color.toArgb() and 0xFFFFFF).toString(16).padStart(6, '0').uppercase()
             userRepository.updateSettings(UpdateSettingsRequest(topBarColor = hex))
         }
+    }
+
+    private suspend fun uploadImageToItemStorage(
+        bytes: ByteArray,
+        itemType: String,
+        mimeType: String
+    ): String {
+        val initiateResp = api.initiateItemUpload(
+            InitiateItemUploadRequest(
+                itemType = itemType,
+                mimeType = mimeType,
+                sizeBytes = bytes.size.toLong()
+            )
+        )
+        api.uploadBytesToPresignedUrl(initiateResp.uploadUrl, bytes, mimeType)
+        val confirmResp = api.confirmItemUpload(initiateResp.itemId)
+        if (!confirmResp.success) {
+            throw Exception("Upload confirmation failed for item ${initiateResp.itemId}")
+        }
+        return initiateResp.itemId
     }
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AuthScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AuthScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.memegram.localization.LocalStrings
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
 
 @Composable
 fun AuthScreen(
@@ -30,10 +32,12 @@ fun AuthScreen(
     viewModel: AuthViewModel,
     onAddDevice: () -> Unit,
     languageViewModel: LanguageViewModel,
+    themeViewModel: ThemeViewModel,
 ) {
     val state by viewModel.uiState.collectAsState()
     val s = LocalStrings.current
     val currentLang by languageViewModel.currentLang.collectAsState()
+    val isDarkMode by themeViewModel.isDarkMode.collectAsState()
     var isLoginMode by remember { mutableStateOf(false) }
     var username by remember { mutableStateOf("") }
     var inviteCode by remember { mutableStateOf("") }
@@ -46,6 +50,19 @@ fun AuthScreen(
     )
     val currentFlag = languages.find { it.code == currentLang }?.flag ?: "\uD83C\uDDFA\uD83C\uDDF8"
 
+    // Colors that adapt to dark mode
+    val bgGradientStart = if (isDarkMode) Color(0xFF1B1B2F) else Color(0xFFF8F7FF)
+    val bgGradientEnd = if (isDarkMode) Color(0xFF162447) else Color(0xFFEDE9FF)
+    val cardBg = if (isDarkMode) Color(0xFF2A2A3E) else Color.White
+    val accentColor = Color(0xFF6075F2)
+    val textPrimary = if (isDarkMode) Color(0xFFE4E1E6) else Color(0xFF1A1A2E)
+    val textSecondary = if (isDarkMode) Color(0xFFA0A0B8) else Color(0xFF888AA0)
+    val borderColor = if (isDarkMode) Color(0xFF3A3A50) else Color(0xFFE0E0E0)
+    val errorBg = if (isDarkMode) Color(0xFF3D1F1F) else Color(0xFFFFEDED)
+    val buttonBg = if (isDarkMode) Color(0xFF7B8BF5) else Color(0xFF6075F2)
+    val buttonDisabled = if (isDarkMode) Color(0xFF4A4A6A) else Color(0xFFB0B8F8)
+    val iconBubbleBg = if (isDarkMode) Color(0xFF2A2A3E) else Color.White
+
     LaunchedEffect(state) {
         if (state is AuthState.Success) onLoginSuccess()
     }
@@ -55,59 +72,92 @@ fun AuthScreen(
             .fillMaxSize()
             .background(
                 Brush.verticalGradient(
-                    colors = listOf(Color(0xFFF8F7FF), Color(0xFFEDE9FF))
+                    colors = listOf(bgGradientStart, bgGradientEnd)
                 )
             )
     ) {
-        Box(
+        Row(
             modifier = Modifier
                 .align(Alignment.TopEnd)
                 .statusBarsPadding()
-                .padding(top = 16.dp, end = 16.dp)
+                .padding(top = 16.sdp, end = 16.sdp),
+            horizontalArrangement = Arrangement.spacedBy(10.sdp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Surface(
                 modifier = Modifier
-                    .size(44.dp)
+                    .size(44.sdp)
                     .clip(CircleShape)
-                    .clickable { showLangMenu = true },
+                    .clickable { themeViewModel.toggleDarkMode() },
                 shape = CircleShape,
-                color = Color.White,
-                shadowElevation = 4.dp,
+                color = iconBubbleBg,
+                shadowElevation = 4.sdp,
             ) {
                 Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-                    Text(text = currentFlag, fontSize = 22.sp)
+                    AnimatedContent(
+                        targetState = isDarkMode,
+                        transitionSpec = {
+                            (fadeIn() + scaleIn()) togetherWith (fadeOut() + scaleOut())
+                        }
+                    ) { dark ->
+                        Icon(
+                            imageVector = if (dark) Icons.Default.DarkMode else Icons.Default.LightMode,
+                            contentDescription = null,
+                            tint = if (dark) Color(0xFFFFC107) else Color(0xFFFF9800),
+                            modifier = Modifier.size(24.sdp)
+                        )
+                    }
                 }
             }
-            DropdownMenu(
-                expanded = showLangMenu,
-                onDismissRequest = { showLangMenu = false }
-            ) {
-                languages.forEach { lang ->
-                    DropdownMenuItem(
-                        text = {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Text(text = lang.flag, fontSize = 20.sp)
-                                Spacer(Modifier.width(12.dp))
-                                Text(
-                                    text = lang.label,
-                                    fontWeight = if (lang.code == currentLang) FontWeight.Bold else FontWeight.Normal,
-                                    color = if (lang.code == currentLang) Color(0xFF6075F2) else Color.Unspecified
-                                )
+
+            // Language selector
+            Box {
+                Surface(
+                    modifier = Modifier
+                        .size(44.sdp)
+                        .clip(CircleShape)
+                        .clickable { showLangMenu = true },
+                    shape = CircleShape,
+                    color = iconBubbleBg,
+                    shadowElevation = 4.sdp,
+                ) {
+                    Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                        Text(text = currentFlag, fontSize = 22.ssp)
+                    }
+                }
+                DropdownMenu(
+                    expanded = showLangMenu,
+                    onDismissRequest = { showLangMenu = false }
+                ) {
+                    languages.forEach { lang ->
+                        DropdownMenuItem(
+                            text = {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Text(text = lang.flag, fontSize = 20.ssp)
+                                    Spacer(Modifier.width(12.sdp))
+                                    Text(
+                                        text = lang.label,
+                                        fontWeight = if (lang.code == currentLang) FontWeight.Bold else FontWeight.Normal,
+                                        color = if (lang.code == currentLang) accentColor else Color.Unspecified
+                                    )
+                                }
+                            },
+                            onClick = {
+                                languageViewModel.setLanguage(lang.code)
+                                showLangMenu = false
                             }
-                        },
-                        onClick = {
-                            languageViewModel.setLanguage(lang.code)
-                            showLangMenu = false
-                        }
-                    )
+                        )
+                    }
                 }
             }
         }
 
         Column(
             modifier = Modifier
+                .widthIn(max = 480.dp)
                 .fillMaxSize()
-                .padding(horizontal = 28.dp),
+                .align(Alignment.TopCenter)
+                .padding(horizontal = 28.sdp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
@@ -115,21 +165,21 @@ fun AuthScreen(
             Text(
                 text = buildAnnotatedString {
                     withStyle(SpanStyle(color = Color.Red)) { append("Meme") }
-                    withStyle(SpanStyle(color = Color(0xFF1A1A2E))) { append("Gram") }
+                    withStyle(SpanStyle(color = textPrimary)) { append("Gram") }
                 },
-                fontSize = 38.sp,
+                fontSize = 38.ssp,
                 fontWeight = FontWeight.Bold,
             )
 
-            Spacer(modifier = Modifier.height(36.dp))
+            Spacer(modifier = Modifier.height(36.sdp))
 
             Card(
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(24.dp),
-                colors = CardDefaults.cardColors(containerColor = Color.White),
-                elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+                shape = RoundedCornerShape(24.sdp),
+                colors = CardDefaults.cardColors(containerColor = cardBg),
+                elevation = CardDefaults.cardElevation(defaultElevation = 4.sdp)
             ) {
-                Column(modifier = Modifier.padding(20.dp)) {
+                Column(modifier = Modifier.padding(20.sdp)) {
                     AnimatedVisibility(
                         visible = !isLoginMode,
                         enter = fadeIn() + expandVertically(),
@@ -141,14 +191,20 @@ fun AuthScreen(
                                 onValueChange = { username = it },
                                 label = s.nickname,
                                 icon = Icons.Default.Person,
+                                isDarkMode = isDarkMode,
+                                accentColor = accentColor,
+                                borderColor = borderColor,
                             )
-                            Spacer(modifier = Modifier.height(12.dp))
+                            Spacer(modifier = Modifier.height(12.sdp))
                             AuthTextField(
                                 value = inviteCode,
                                 onValueChange = { inviteCode = it },
                                 label = s.inviteCode,
                                 icon = Icons.Default.CardGiftcard,
                                 placeholder = "XXXXXXXX",
+                                isDarkMode = isDarkMode,
+                                accentColor = accentColor,
+                                borderColor = borderColor,
                             )
                         }
                     }
@@ -160,12 +216,12 @@ fun AuthScreen(
                     ) {
                         Text(
                             text = s.autoLoginHint,
-                            fontSize = 14.sp,
-                            color = Color(0xFF888AA0),
+                            fontSize = 14.ssp,
+                            color = textSecondary,
                             textAlign = TextAlign.Center,
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(vertical = 8.dp)
+                                .padding(vertical = 8.sdp)
                         )
                     }
                 }
@@ -175,31 +231,31 @@ fun AuthScreen(
                 Card(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(top = 12.dp),
-                    shape = RoundedCornerShape(12.dp),
-                    colors = CardDefaults.cardColors(containerColor = Color(0xFFFFEDED))
+                        .padding(top = 12.sdp),
+                    shape = RoundedCornerShape(12.sdp),
+                    colors = CardDefaults.cardColors(containerColor = errorBg)
                 ) {
                     Row(
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+                        modifier = Modifier.padding(horizontal = 16.sdp, vertical = 10.sdp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Icon(
                             Icons.Default.ErrorOutline,
                             contentDescription = null,
                             tint = Color(0xFFD32F2F),
-                            modifier = Modifier.size(18.dp)
+                            modifier = Modifier.size(18.sdp)
                         )
-                        Spacer(modifier = Modifier.width(8.dp))
+                        Spacer(modifier = Modifier.width(8.sdp))
                         Text(
                             text = (state as? AuthState.Error)?.message ?: "",
                             color = Color(0xFFD32F2F),
-                            fontSize = 13.sp
+                            fontSize = 13.ssp
                         )
                     }
                 }
             }
 
-            Spacer(modifier = Modifier.height(20.dp))
+            Spacer(modifier = Modifier.height(20.sdp))
 
             Button(
                 onClick = {
@@ -208,38 +264,38 @@ fun AuthScreen(
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(54.dp),
-                shape = RoundedCornerShape(16.dp),
+                    .height(54.sdp),
+                shape = RoundedCornerShape(16.sdp),
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = Color(0xFF6075F2),
-                    disabledContainerColor = Color(0xFFB0B8F8)
+                    containerColor = buttonBg,
+                    disabledContainerColor = buttonDisabled
                 ),
                 enabled = state !is AuthState.Loading
             ) {
                 if (state is AuthState.Loading) {
                     CircularProgressIndicator(
-                        modifier = Modifier.size(22.dp),
+                        modifier = Modifier.size(22.sdp),
                         color = Color.White,
-                        strokeWidth = 2.5.dp
+                        strokeWidth = 2.5.sdp
                     )
                 } else {
                     Text(
                         text = if (isLoginMode) s.login else s.register,
-                        fontSize = 16.sp,
+                        fontSize = 16.ssp,
                         fontWeight = FontWeight.SemiBold,
                         color = Color.White
                     )
                 }
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(16.sdp))
 
             TextButton(onClick = { isLoginMode = !isLoginMode }) {
                 Text(
                     text = if (isLoginMode) s.noAccountRegister
                     else s.hasAccountLogin,
-                    color = Color(0xFF6075F2),
-                    fontSize = 14.sp,
+                    color = accentColor,
+                    fontSize = 14.ssp,
                     textAlign = TextAlign.Center
                 )
             }
@@ -250,9 +306,9 @@ fun AuthScreen(
                 Icon(
                     imageVector = Icons.Default.QrCode,
                     contentDescription = null,
-                    modifier = Modifier.size(18.dp)
+                    modifier = Modifier.size(18.sdp)
                 )
-                Spacer(Modifier.width(8.dp))
+                Spacer(Modifier.width(8.sdp))
                 Text(s.loginFromOtherDevice)
             }
         }
@@ -266,22 +322,26 @@ private fun AuthTextField(
     label: String,
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     placeholder: String = "",
+    isDarkMode: Boolean = false,
+    accentColor: Color = Color(0xFF6075F2),
+    borderColor: Color = Color(0xFFE0E0E0),
 ) {
+    val placeholderColor = if (isDarkMode) Color(0xFF666680) else Color(0xFFCCCCCC)
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
-        label = { Text(label, fontSize = 14.sp) },
-        placeholder = if (placeholder.isNotEmpty()) {{ Text(placeholder, color = Color(0xFFCCCCCC)) }} else null,
+        label = { Text(label, fontSize = 14.ssp) },
+        placeholder = if (placeholder.isNotEmpty()) {{ Text(placeholder, color = placeholderColor) }} else null,
         leadingIcon = {
-            Icon(icon, contentDescription = null, tint = Color(0xFF6075F2), modifier = Modifier.size(20.dp))
+            Icon(icon, contentDescription = null, tint = accentColor, modifier = Modifier.size(20.sdp))
         },
         modifier = Modifier.fillMaxWidth(),
         singleLine = true,
-        shape = RoundedCornerShape(12.dp),
+        shape = RoundedCornerShape(12.sdp),
         colors = OutlinedTextFieldDefaults.colors(
-            focusedBorderColor = Color(0xFF6075F2),
-            unfocusedBorderColor = Color(0xFFE0E0E0),
-            focusedLabelColor = Color(0xFF6075F2),
+            focusedBorderColor = accentColor,
+            unfocusedBorderColor = borderColor,
+            focusedLabelColor = accentColor,
         )
     )
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AvatarImage.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/AvatarImage.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import org.koin.compose.koinInject
+import com.example.memegram.utils.sdp
 
 @Composable
 fun AvatarImage(
@@ -29,7 +29,7 @@ fun AvatarImage(
     backgroundColor: Color = Color(0xFF6075F2),
     textColor: Color = Color.White,
     textStyle: TextStyle? = null,
-    borderWidth: Dp = 0.dp,
+    borderWidth: Dp = 0.sdp,
     borderColor: Color = Color.White
 ) {
     val avatarCache = koinInject<AvatarCache>()
@@ -46,7 +46,7 @@ fun AvatarImage(
         .clip(CircleShape)
         .background(backgroundColor)
         .then(
-            if (borderWidth > 0.dp) Modifier.border(borderWidth, borderColor, CircleShape)
+            if (borderWidth > 0.sdp) Modifier.border(borderWidth, borderColor, CircleShape)
             else Modifier
         )
 

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/BlackListScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/BlackListScreen.kt
@@ -20,6 +20,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.memegram.localization.LocalStrings
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
+import com.example.memegram.utils.ImageTopAppBarBox
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -67,6 +70,7 @@ fun BlackListScreen(
 
     Scaffold(
         topBar = {
+            ImageTopAppBarBox(topBarColor) { bgColor ->
             TopAppBar(
                 title = { Text(s.blackListTitle) },
                 navigationIcon = {
@@ -75,11 +79,12 @@ fun BlackListScreen(
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = topBarColor,
+                    containerColor = bgColor,
                     titleContentColor = topBarTextColor,
                     navigationIconContentColor = topBarTextColor
                 )
             )
+            }
         }
     ) { paddingValues ->
         Box(
@@ -103,13 +108,13 @@ fun BlackListScreen(
                             color = Color.Gray,
                             textAlign = TextAlign.Center
                         )
-                        Spacer(Modifier.height(6.dp))
+                        Spacer(Modifier.height(6.sdp))
                         Text(
                             text = s.blockedUsersHint,
                             style = MaterialTheme.typography.bodySmall,
                             color = Color.Gray,
                             textAlign = TextAlign.Center,
-                            modifier = Modifier.padding(horizontal = 32.dp)
+                            modifier = Modifier.padding(horizontal = 32.sdp)
                         )
                     }
                 }
@@ -125,7 +130,7 @@ fun BlackListScreen(
                                 onUnblock = { pendingUnblockId = entry.blockedUserId }
                             )
                             HorizontalDivider(
-                                modifier = Modifier.padding(start = 72.dp),
+                                modifier = Modifier.padding(start = 72.sdp),
                                 color = MaterialTheme.colorScheme.surfaceVariant
                             )
                         }
@@ -146,14 +151,14 @@ private fun BlockedUserItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = 16.sdp, vertical = 12.sdp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Box(
                 modifier = Modifier
-                    .size(46.dp)
+                    .size(46.sdp)
                     .clip(CircleShape)
                     .background(accentColor.copy(alpha = 0.15f)),
                 contentAlignment = Alignment.Center
@@ -162,10 +167,10 @@ private fun BlockedUserItem(
                     text = displayName.take(1).uppercase(),
                     color = accentColor,
                     fontWeight = FontWeight.Bold,
-                    fontSize = 18.sp
+                    fontSize = 18.ssp
                 )
             }
-            Spacer(Modifier.width(14.dp))
+            Spacer(Modifier.width(14.sdp))
             Text(
                 text = displayName,
                 style = MaterialTheme.typography.bodyLarge,
@@ -175,12 +180,12 @@ private fun BlockedUserItem(
 
         TextButton(
             onClick = onUnblock,
-            shape = RoundedCornerShape(10.dp),
+            shape = RoundedCornerShape(10.sdp),
             colors = ButtonDefaults.textButtonColors(
                 contentColor = MaterialTheme.colorScheme.error
             )
         ) {
-            Text(unblockLabel, fontSize = 13.sp)
+            Text(unblockLabel, fontSize = 13.ssp)
         }
     }
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatModel.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatModel.kt
@@ -25,7 +25,8 @@ data class Message(
     val encryptionMetadata: String? = null,
     val localPreviewBytes: ByteArray? = null,
     val mediaUrl: String? = null,
-    val senderUserId: String? = null
+    val senderUserId: String? = null,
+    val groupId: String? = null
 )
 
 enum class MessageStatus { SENDING, SENT, FAILED }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
@@ -41,6 +42,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
@@ -72,6 +74,11 @@ import org.koin.compose.koinInject
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Instant
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
+import com.example.memegram.utils.ImageTopAppBarBox
+import com.example.memegram.utils.LocalScreenWidthDp
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -88,6 +95,9 @@ fun ChatScreen(
     val chatBgColor    by viewModel.chatBgColor.collectAsState()
     val myBubbleColor  by viewModel.myBubbleColor.collectAsState()
     val theirBubbleColor by viewModel.theirBubbleColor.collectAsState()
+    val chatBgImage    by viewModel.chatBgImage.collectAsState()
+    val myBubbleImage  by viewModel.myBubbleImage.collectAsState()
+    val theirBubbleImage by viewModel.theirBubbleImage.collectAsState()
     val mediaCache by viewModel.mediaCache.collectAsState()
     val topBarTextColor = if (topBarColor.luminance() > 0.5f) Color.Black else Color.White
 
@@ -96,14 +106,15 @@ fun ChatScreen(
 
     val listState = rememberLazyListState()
 
+    val chatItems by remember { derivedStateOf { groupMessages(messages) } }
+
     val lastVisibleIncomingServerId by remember {
         derivedStateOf {
             val visible = listState.layoutInfo.visibleItemsInfo
-            if (visible.isEmpty()) return@derivedStateOf null
+            if (visible.isEmpty() || chatItems.isEmpty()) return@derivedStateOf null
             visible
-                .asReversed()
-                .mapNotNull { info -> messages.getOrNull(info.index) }
-                .firstOrNull { !it.isOutgoing && it.serverId.isNotBlank() }
+                .flatMap { info -> chatItems.getOrNull(info.index)?.allMessages ?: emptyList() }
+                .lastOrNull { !it.isOutgoing && it.serverId.isNotBlank() }
                 ?.serverId
         }
     }
@@ -115,8 +126,44 @@ fun ChatScreen(
         lastVisibleIncomingServerId?.let(viewModel::markMessagesRead)
     }
 
-    LaunchedEffect(messages.size) {
-        if (messages.isNotEmpty()) listState.animateScrollToItem(messages.size - 1)
+    var scrollRestored by remember { mutableStateOf(false) }
+    val initialUnreadCount by viewModel.initialUnreadCount.collectAsState()
+
+    LaunchedEffect(chatItems.size) {
+        if (chatItems.isEmpty()) return@LaunchedEffect
+        if (!scrollRestored) {
+            val convId = viewModel.currentConversationId
+            val saved = convId?.let { ChatScrollCache.restore(it) }
+            if (saved != null) {
+                listState.scrollToItem(saved.first.coerceAtMost(chatItems.lastIndex), saved.second)
+            } else if (initialUnreadCount > 0 && initialUnreadCount < messages.size) {
+                val lastReadMsgIdx = (messages.size - initialUnreadCount - 1).coerceAtLeast(0)
+                val lastReadMsg = messages[lastReadMsgIdx]
+                val chatItemIdx = chatItems.indexOfFirst { item ->
+                    item.allMessages.any { it.id == lastReadMsg.id }
+                }.coerceAtLeast(0)
+                listState.scrollToItem(chatItemIdx)
+            } else {
+                listState.scrollToItem(chatItems.lastIndex)
+            }
+            scrollRestored = true
+        } else {
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()
+            if (lastVisible != null && lastVisible.index >= chatItems.size - 3) {
+                listState.animateScrollToItem(chatItems.lastIndex)
+            }
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            val convId = viewModel.currentConversationId ?: return@onDispose
+            ChatScrollCache.save(
+                convId,
+                listState.firstVisibleItemIndex,
+                listState.firstVisibleItemScrollOffset
+            )
+        }
     }
 
     var attachments by remember { mutableStateOf<List<AttachItem>>(emptyList()) }
@@ -127,6 +174,12 @@ fun ChatScreen(
     var galleryLoading by remember { mutableStateOf(false) }
     val gridState      = rememberLazyGridState()
     val gallerySections = remember(galleryThumbs) { buildGallerySections(galleryThumbs) }
+    val screenWidthDp = LocalScreenWidthDp.current
+    val defaultGridColumns = remember(screenWidthDp) {
+        (screenWidthDp / 120f).roundToInt().coerceIn(2, 6)
+    }
+    var gridColumns by remember(defaultGridColumns) { mutableIntStateOf(defaultGridColumns) }
+    var pinchAccumulatedScale by remember { mutableFloatStateOf(1f) }
 
     LaunchedEffect(showAttachSheet, galleryLoader.isPermissionGranted) {
         if (showAttachSheet && galleryLoader.isPermissionGranted && galleryThumbs.isEmpty() && !galleryLoading) {
@@ -155,20 +208,26 @@ fun ChatScreen(
     var currentMatchIdx  by remember { mutableIntStateOf(0) }
     val searchFocus      = remember { FocusRequester() }
 
-    val searchMatches = remember(messages, searchQuery) {
+    val searchMatches = remember(chatItems, searchQuery) {
         if (searchQuery.isBlank()) emptyList()
-        else messages.mapIndexedNotNull { i, m ->
-            if (m.text.contains(searchQuery, ignoreCase = true)) i else null
+        else chatItems.mapIndexedNotNull { i, item ->
+            if (item.allMessages.any { it.text.contains(searchQuery, ignoreCase = true) }) i else null
         }
     }
     val currentMatchMsgId = remember(searchMatches, currentMatchIdx) {
-        if (searchMatches.isNotEmpty()) messages[searchMatches[currentMatchIdx]].id else -1
+        if (searchMatches.isNotEmpty()) {
+            val item = chatItems[searchMatches[currentMatchIdx]]
+            item.allMessages.firstOrNull { it.text.contains(searchQuery, ignoreCase = true) }?.id ?: -1
+        } else -1
     }
 
     LaunchedEffect(searchQuery)   { currentMatchIdx = if (searchMatches.isNotEmpty()) searchMatches.size - 1 else 0 }
     LaunchedEffect(isSearchMode)  { if (isSearchMode) searchFocus.requestFocus() else searchQuery = "" }
     LaunchedEffect(currentMatchIdx, searchMatches.size) {
-        if (searchMatches.isNotEmpty()) listState.animateScrollToItem(searchMatches[currentMatchIdx])
+        if (searchMatches.isNotEmpty()) {
+            val origIdx = searchMatches[currentMatchIdx]
+            listState.animateScrollToItem(origIdx)
+        }
     }
 
     var showMenu        by remember { mutableStateOf(false) }
@@ -188,7 +247,7 @@ fun ChatScreen(
     val coroutineScope = rememberCoroutineScope()
     var contextMenuMessage by remember { mutableStateOf<Message?>(null) }
     var contextMenuOffset by remember { mutableStateOf(DpOffset.Zero) }
-    var messageToDelete by remember { mutableStateOf<Message?>(null) }
+    var messagesToDelete by remember { mutableStateOf<List<Message>?>(null) }
 
     val recordState     by viewModel.recordState.collectAsState()
     val recordAmps      by viewModel.voiceAmplitudes.collectAsState()
@@ -205,7 +264,7 @@ fun ChatScreen(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(460.dp)
+                    .height(460.sdp)
                     .navigationBarsPadding()
             ) {
                 Column(modifier = Modifier.fillMaxSize()) {
@@ -213,27 +272,27 @@ fun ChatScreen(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                            .padding(horizontal = 16.sdp, vertical = 8.sdp),
                         verticalAlignment         = Alignment.CenterVertically,
                         horizontalArrangement     = Arrangement.SpaceBetween
                     ) {
                         Text(s.gallery, style = MaterialTheme.typography.titleMedium)
-                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.sdp)) {
                             OutlinedButton(
                                 onClick        = { filePicker.launch(); showAttachSheet = false },
-                                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp)
+                                contentPadding = PaddingValues(horizontal = 12.sdp, vertical = 6.sdp)
                             ) {
-                                Icon(Icons.Default.AttachFile, null, modifier = Modifier.size(16.dp))
-                                Spacer(Modifier.width(4.dp))
-                                Text(s.file, fontSize = 13.sp)
+                                Icon(Icons.Default.AttachFile, null, modifier = Modifier.size(16.sdp))
+                                Spacer(Modifier.width(4.sdp))
+                                Text(s.file, fontSize = 13.ssp)
                             }
                             OutlinedButton(
                                 onClick        = { imagePicker.launch(); showAttachSheet = false },
-                                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp)
+                                contentPadding = PaddingValues(horizontal = 12.sdp, vertical = 6.sdp)
                             ) {
-                                Icon(Icons.Default.PhotoLibrary, null, modifier = Modifier.size(16.dp))
-                                Spacer(Modifier.width(4.dp))
-                                Text(s.all, fontSize = 13.sp)
+                                Icon(Icons.Default.PhotoLibrary, null, modifier = Modifier.size(16.sdp))
+                                Spacer(Modifier.width(4.sdp))
+                                Text(s.all, fontSize = 13.ssp)
                             }
                         }
                     }
@@ -254,30 +313,70 @@ fun ChatScreen(
                                     modifier            = Modifier.align(Alignment.Center),
                                     horizontalAlignment = Alignment.CenterHorizontally
                                 ) {
-                                    Icon(Icons.Default.PhotoLibrary, null, modifier = Modifier.size(48.dp), tint = Color.Gray)
-                                    Spacer(Modifier.height(8.dp))
+                                    Icon(Icons.Default.PhotoLibrary, null, modifier = Modifier.size(48.sdp), tint = Color.Gray)
+                                    Spacer(Modifier.height(8.sdp))
                                     Text(s.noGalleryAccess, color = Color.Gray)
-                                    Spacer(Modifier.height(8.dp))
+                                    Spacer(Modifier.height(8.sdp))
                                     Button(onClick = { imagePicker.launch(); showAttachSheet = false }) {
                                         Text(s.openGallery)
                                     }
                                 }
                             }
                             else -> {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .pointerInput(Unit) {
+                                            awaitPointerEventScope {
+                                                while (true) {
+                                                    val event = awaitPointerEvent(PointerEventPass.Final)
+                                                    val pressed = event.changes.filter { it.pressed }
+                                                    if (pressed.size >= 2) {
+                                                        event.changes.forEach { it.consume() }
+                                                        var prevDist = (pressed[0].position - pressed[1].position).getDistance()
+
+                                                        var tracking = true
+                                                        while (tracking) {
+                                                            val next = awaitPointerEvent(PointerEventPass.Final)
+                                                            val nextPressed = next.changes.filter { it.pressed }
+                                                            if (nextPressed.size >= 2) {
+                                                                next.changes.forEach { it.consume() }
+                                                                val dist = (nextPressed[0].position - nextPressed[1].position).getDistance()
+                                                                if (dist > 0f && prevDist > 0f) {
+                                                                    pinchAccumulatedScale *= (dist / prevDist)
+                                                                    if (pinchAccumulatedScale > 1.5f) {
+                                                                        gridColumns = (gridColumns - 1).coerceAtLeast(2)
+                                                                        pinchAccumulatedScale = 1f
+                                                                    } else if (pinchAccumulatedScale < 0.67f) {
+                                                                        gridColumns = (gridColumns + 1).coerceAtMost(6)
+                                                                        pinchAccumulatedScale = 1f
+                                                                    }
+                                                                }
+                                                                prevDist = dist
+                                                            } else {
+                                                                tracking = false
+                                                                pinchAccumulatedScale = 1f
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                ) {
                                 LazyVerticalGrid(
                                     state          = gridState,
-                                    columns        = GridCells.Fixed(3),
+                                    columns        = GridCells.Fixed(gridColumns),
                                     modifier       = Modifier
                                         .fillMaxSize()
-                                        .padding(end = 36.dp),
+                                        .padding(end = 36.sdp),
                                     contentPadding = PaddingValues(
-                                        start  = 2.dp,
-                                        top    = 2.dp,
-                                        end    = 2.dp,
-                                        bottom = if (pendingGallery.isNotEmpty()) 70.dp else 2.dp
+                                        start  = 2.sdp,
+                                        top    = 2.sdp,
+                                        end    = 2.sdp,
+                                        bottom = if (pendingGallery.isNotEmpty()) 70.sdp else 2.sdp
                                     ),
-                                    horizontalArrangement = Arrangement.spacedBy(2.dp),
-                                    verticalArrangement   = Arrangement.spacedBy(2.dp)
+                                    horizontalArrangement = Arrangement.spacedBy(2.sdp),
+                                    verticalArrangement   = Arrangement.spacedBy(2.sdp)
                                 ) {
                                     items(galleryThumbs, key = { it.id }) { thumb ->
                                         val isSelected = thumb in pendingGallery
@@ -299,11 +398,12 @@ fun ChatScreen(
                                     sections   = gallerySections,
                                     totalItems = galleryThumbs.size,
                                     gridState  = gridState,
-                                    columns    = 3,
+                                    columns    = gridColumns,
                                     modifier   = Modifier
                                         .align(Alignment.CenterEnd)
                                         .fillMaxHeight()
                                 )
+                                }
                             }
                         }
                     }
@@ -315,7 +415,7 @@ fun ChatScreen(
                             .align(Alignment.BottomCenter)
                             .fillMaxWidth()
                             .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.97f))
-                            .padding(horizontal = 16.dp, vertical = 10.dp)
+                            .padding(horizontal = 16.sdp, vertical = 10.sdp)
                     ) {
                         Button(
                             onClick  = {
@@ -327,8 +427,8 @@ fun ChatScreen(
                             },
                             modifier = Modifier.fillMaxWidth()
                         ) {
-                            Icon(Icons.AutoMirrored.Filled.Send, null, modifier = Modifier.size(18.dp))
-                            Spacer(Modifier.width(8.dp))
+                            Icon(Icons.AutoMirrored.Filled.Send, null, modifier = Modifier.size(18.sdp))
+                            Spacer(Modifier.width(8.sdp))
                             Text(s.attachNPhotos(pendingGallery.size))
                         }
                     }
@@ -399,15 +499,15 @@ fun ChatScreen(
             text = {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     Box(
-                        modifier = Modifier.size(240.dp).clip(CircleShape).background(MaterialTheme.colorScheme.primary),
+                        modifier = Modifier.size(240.sdp).clip(CircleShape).background(MaterialTheme.colorScheme.primary),
                         contentAlignment = Alignment.Center
                     ) {
-                        Text(chatName.take(1).uppercase(), color = Color.White, fontSize = 100.sp)
+                        Text(chatName.take(1).uppercase(), color = Color.White, fontSize = 100.ssp)
                     }
 
                     IconButton(
                         onClick = { showFullScreenAvatar = false },
-                        modifier = Modifier.align(Alignment.TopStart).padding(16.dp).statusBarsPadding()
+                        modifier = Modifier.align(Alignment.TopStart).padding(16.sdp).statusBarsPadding()
                     ) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = Color.White)
                     }
@@ -417,26 +517,27 @@ fun ChatScreen(
         )
     }
 
-    if (messageToDelete != null) {
+    if (messagesToDelete != null) {
         AlertDialog(
-            onDismissRequest = { messageToDelete = null },
+            onDismissRequest = { messagesToDelete = null },
             title = { Text(s.deleteMessageTitle) },
             text = { Text(s.deleteMessageText) },
             confirmButton = {
                 TextButton(
                     onClick = {
-                        messageToDelete?.let { viewModel.deleteMessage(it) }
-                        messageToDelete = null
+                        messagesToDelete?.forEach { viewModel.deleteMessage(it) }
+                        messagesToDelete = null
                     },
                     colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
                 ) { Text(s.deleteForAll) }
             },
-            dismissButton = { TextButton(onClick = { messageToDelete = null }) { Text(s.cancel) } }
+            dismissButton = { TextButton(onClick = { messagesToDelete = null }) { Text(s.cancel) } }
         )
     }
 
     Scaffold(
         topBar = {
+            ImageTopAppBarBox(topBarColor) { bgColor ->
             TopAppBar(
                 navigationIcon = {
                     IconButton(onClick = { if (isSearchMode) isSearchMode = false else onBack() }) {
@@ -449,19 +550,19 @@ fun ChatScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable { onProfileClick() }
-                            .padding(end = 16.dp)
+                            .padding(end = 16.sdp)
                     ) {
                         Box(modifier = Modifier.clickable { showFullScreenAvatar = true }) {
                             AvatarImage(
                                 mediaId = if (!isGroupChat) peerAvatarMediaId else null,
-                                size = 36.dp,
+                                size = 36.sdp,
                                 fallbackLetter = chatName.take(1).uppercase(),
                                 backgroundColor = topBarTextColor.copy(alpha = 0.2f),
                                 textColor = topBarTextColor,
-                                textStyle = TextStyle(fontSize = 16.sp)
+                                textStyle = TextStyle(fontSize = 16.ssp)
                             )
                         }
-                        Spacer(Modifier.width(10.dp))
+                        Spacer(Modifier.width(10.sdp))
                         Text(chatName, color = topBarTextColor)
                     }
                 },
@@ -487,16 +588,17 @@ fun ChatScreen(
                         }
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = topBarColor)
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = bgColor)
             )
+            }
         },
         bottomBar = {
-            Surface(color = MaterialTheme.colorScheme.surface, tonalElevation = 3.dp) {
+            Surface(color = MaterialTheme.colorScheme.surface, tonalElevation = 3.sdp) {
                 Column {
                     if (attachments.isNotEmpty()) {
                         LazyRow(
-                            modifier = Modifier.fillMaxWidth().padding(8.dp),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            modifier = Modifier.fillMaxWidth().padding(8.sdp),
+                            horizontalArrangement = Arrangement.spacedBy(8.sdp)
                         ) {
                             items(attachments) { item -> AttachmentThumbnail(item) { attachments = attachments - item } }
                         }
@@ -508,15 +610,15 @@ fun ChatScreen(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f))
-                                .padding(horizontal = 12.dp, vertical = 8.dp),
+                                .padding(horizontal = 12.sdp, vertical = 8.sdp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Icon(
                                 Icons.AutoMirrored.Filled.Reply, null,
                                 tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.size(20.dp)
+                                modifier = Modifier.size(20.sdp)
                             )
-                            Spacer(Modifier.width(8.dp))
+                            Spacer(Modifier.width(8.sdp))
                             Column(modifier = Modifier.weight(1f)) {
                                 Text(
                                     s.reply,
@@ -538,9 +640,9 @@ fun ChatScreen(
                             }
                             IconButton(
                                 onClick = { viewModel.clearReply() },
-                                modifier = Modifier.size(24.dp)
+                                modifier = Modifier.size(24.sdp)
                             ) {
-                                Icon(Icons.Default.Close, null, modifier = Modifier.size(16.dp))
+                                Icon(Icons.Default.Close, null, modifier = Modifier.size(16.sdp))
                             }
                         }
                         HorizontalDivider()
@@ -549,43 +651,43 @@ fun ChatScreen(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 6.dp)
+                            .padding(horizontal = 4.sdp, vertical = 6.sdp)
                             .navigationBarsPadding(),
                         verticalAlignment = Alignment.Bottom
                     ) {
                         if (recordState != ChatViewModel.RecordState.IDLE) {
                             Row(
-                                modifier = Modifier.weight(1f).height(48.dp).padding(horizontal = 8.dp),
+                                modifier = Modifier.weight(1f).height(48.sdp).padding(horizontal = 8.sdp),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
                                 val alpha by animateFloatAsState(
                                     targetValue = if (recordState == ChatViewModel.RecordState.PAUSED) 0.3f else 1f,
                                     animationSpec = infiniteRepeatable(animation = tween(800), repeatMode = RepeatMode.Reverse)
                                 )
-                                Box(modifier = Modifier.size(10.dp).clip(CircleShape).background(Color.Red.copy(alpha = alpha)))
-                                Spacer(modifier = Modifier.width(8.dp))
+                                Box(modifier = Modifier.size(10.sdp).clip(CircleShape).background(Color.Red.copy(alpha = alpha)))
+                                Spacer(modifier = Modifier.width(8.sdp))
 
                                 val sec = (recordDuration / 1000).toInt()
-                                Text("${sec / 60}:${(sec % 60).toString().padStart(2, '0')}", fontSize = 16.sp)
-                                Spacer(modifier = Modifier.width(16.dp))
+                                Text("${sec / 60}:${(sec % 60).toString().padStart(2, '0')}", fontSize = 16.ssp)
+                                Spacer(modifier = Modifier.width(16.sdp))
 
                                 if (recordState == ChatViewModel.RecordState.HOLDING) {
-                                    Text(s.swipeToCancel, color = Color.Gray, fontSize = 14.sp)
+                                    Text(s.swipeToCancel, color = Color.Gray, fontSize = 14.ssp)
                                 } else {
                                     VoiceWaveform(
                                         amplitudes = recordAmps,
                                         progress = 1f,
-                                        modifier = Modifier.weight(1f).height(30.dp),
+                                        modifier = Modifier.weight(1f).height(30.sdp),
                                         playedColor = MaterialTheme.colorScheme.primary,
                                         unplayedColor = Color.Gray.copy(alpha = 0.3f)
                                     )
 
-                                    IconButton(onClick = { viewModel.cancelVoiceRecording() }, modifier = Modifier.size(32.dp)) {
+                                    IconButton(onClick = { viewModel.cancelVoiceRecording() }, modifier = Modifier.size(32.sdp)) {
                                         Icon(Icons.Default.Delete, null, tint = Color.Gray)
                                     }
                                     IconButton(
                                         onClick = { if (recordState == ChatViewModel.RecordState.PAUSED) viewModel.resumeVoiceRecording() else viewModel.pauseVoiceRecording() },
-                                        modifier = Modifier.size(32.dp)
+                                        modifier = Modifier.size(32.sdp)
                                     ) {
                                         Icon(if (recordState == ChatViewModel.RecordState.PAUSED) Icons.Default.Mic else Icons.Default.Pause, null, tint = MaterialTheme.colorScheme.primary)
                                     }
@@ -596,7 +698,7 @@ fun ChatScreen(
                             OutlinedTextField(
                                 value = inputText, onValueChange = { viewModel.updateInput(it) },
                                 modifier = Modifier.weight(1f), placeholder = { Text(s.messagePlaceholder) },
-                                shape = RoundedCornerShape(24.dp), maxLines = 5
+                                shape = RoundedCornerShape(24.sdp), maxLines = 5
                             )
                             IconButton(onClick = { galleryLoader.requestPermission(); showAttachSheet = true }) {
                                 Icon(Icons.Default.AttachFile, null, tint = Color.Gray, modifier = Modifier.rotate(45f))
@@ -612,7 +714,7 @@ fun ChatScreen(
                         }
 
                         val buttonModifier = Modifier
-                            .size(48.dp)
+                            .size(48.sdp)
                             .clip(CircleShape)
                             .background(sendButtonBg)
                             .then(
@@ -710,213 +812,392 @@ fun ChatScreen(
                     .weight(1f)
                     .background(chatBgColor)
             ) {
+            val chatBgBitmap = remember(chatBgImage) {
+                chatBgImage?.let { runCatching { it.decodeToImageBitmap() }.getOrNull() }
+            }
+            if (chatBgBitmap != null) {
+                Image(
+                    bitmap = chatBgBitmap,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            }
             LazyColumn(
                 state          = listState,
-                modifier       = Modifier.fillMaxSize().padding(horizontal = 12.dp),
-                contentPadding = PaddingValues(vertical = 12.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Bottom)
+                modifier       = Modifier.fillMaxSize().padding(horizontal = 12.sdp),
+                contentPadding = PaddingValues(vertical = 12.sdp),
+                verticalArrangement = Arrangement.spacedBy(8.sdp, Alignment.Bottom)
             ) {
-                items(messages, key = { it.id }) { message ->
-                    if (message.text.isBlank() && message.mediaId == null && message.localPreviewBytes == null) return@items
-                    val senderId = messageSenders[message.serverId]
-                    val profile = memberProfiles[senderId]
-                    val replyToServerId = replyContext[message.serverId]
-                    val replyToMessage = replyToServerId?.let { rid -> messages.find { it.serverId == rid } }
-                    val replyToSenderName = replyToMessage?.let { rm ->
-                        val replySenderId = messageSenders[rm.serverId]
-                        replySenderId?.let { memberProfiles[it]?.username }
-                    }
-                    val isDeleted = message.text == s.messageDeletedEmoji
-                        || message.text == s.messageDeleted
-                        || message.text == "🗑 Сообщение удалено"
-                        || message.text == "Сообщение удалено"
+                items(chatItems.size, key = { chatItems[it].stableKey }) { index ->
+                    val chatItem = chatItems[index]
 
-                    if (message.type == "system") {
-                        Box(
-                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(
-                                text = message.text,
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier
-                                    .background(
-                                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
-                                        RoundedCornerShape(12.dp)
-                                    )
-                                    .padding(horizontal = 12.dp, vertical = 4.dp)
-                            )
-                        }
-                        return@items
-                    }
+                    when (chatItem) {
+                        is ChatItem.Single -> {
+                            val message = chatItem.message
+                            if (message.text.isBlank() && message.mediaId == null && message.localPreviewBytes == null) return@items
+                            val senderId = messageSenders[message.serverId]
+                            val profile = memberProfiles[senderId]
+                            val replyToServerId = replyContext[message.serverId]
+                            val replyToMessage = replyToServerId?.let { rid -> messages.find { it.serverId == rid } }
+                            val replyToSenderName = replyToMessage?.let { rm ->
+                                val replySenderId = messageSenders[rm.serverId]
+                                replySenderId?.let { memberProfiles[it]?.username }
+                            }
 
-                    Box {
-                        if (isGroupChat && !message.isOutgoing) {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(bottom = 2.dp)
-                                    .pointerInput(message.id) {
-                                        detectTapGestures(
-                                            onLongPress = { offset ->
-                                                if (!isDeleted) {
-                                                    with(density) {
-                                                        contextMenuOffset = DpOffset(
-                                                            x = offset.x.toDp(),
-                                                            y = offset.y.toDp()
-                                                        )
-                                                    }
-                                                    contextMenuMessage = message
-                                                }
-                                            }
-                                        )
-                                    },
-                                horizontalArrangement = Arrangement.Start,
-                                verticalAlignment = Alignment.Bottom
-                            ) {
+                            if (message.type == "system") {
                                 Box(
-                                    modifier = Modifier
-                                        .size(36.dp)
+                                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.sdp),
+                                    contentAlignment = Alignment.Center
                                 ) {
-                                    AvatarImage(
-                                        mediaId = profile?.avatarMediaId,
-                                        size = 36.dp,
-                                        fallbackLetter = profile?.username?.take(1)?.uppercase() ?: "?",
-                                        backgroundColor = MaterialTheme.colorScheme.primaryContainer,
-                                        textColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                                        textStyle = TextStyle(fontSize = 14.sp)
-                                    )
-                                }
-
-                                Spacer(modifier = Modifier.width(8.dp))
-
-                                Column(horizontalAlignment = Alignment.Start) {
                                     Text(
-                                        text = profile?.username ?: s.member,
-                                        style = MaterialTheme.typography.labelMedium,
-                                        color = MaterialTheme.colorScheme.primary,
-                                        modifier = Modifier.padding(start = 4.dp, bottom = 2.dp)
-                                    )
-
-                                    MessageBubble(
-                                        message          = message,
-                                        myBubbleColor    = myBubbleColor,
-                                        theirBubbleColor = theirBubbleColor,
-                                        searchQuery      = searchQuery,
-                                        isCurrentMatch   = message.id == currentMatchMsgId,
-                                        mediaCache       = mediaCache,
-                                        onLoadMedia      = { id, meta -> viewModel.loadMedia(id, meta) },
-                                        globalAudioPlayer = globalAudioPlayer,
-                                        chatName         = chatName,
-                                        replyToMessage   = replyToMessage,
-                                        replyToSenderName = replyToSenderName,
-                                        onReplyClick     = replyToMessage?.let { replied ->
-                                            {
-                                                val idx = messages.indexOfFirst { it.serverId == replied.serverId }
-                                                if (idx >= 0) coroutineScope.launch { listState.animateScrollToItem(idx) }
-                                            }
-                                        }
+                                        text = message.text,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier = Modifier
+                                            .background(
+                                                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+                                                RoundedCornerShape(12.sdp)
+                                            )
+                                            .padding(horizontal = 12.sdp, vertical = 4.sdp)
                                     )
                                 }
+                                return@items
                             }
-                        } else {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .pointerInput(message.id) {
-                                        detectTapGestures(
-                                            onLongPress = { offset ->
-                                                if (!isDeleted) {
-                                                    with(density) {
-                                                        contextMenuOffset = DpOffset(
-                                                            x = offset.x.toDp(),
-                                                            y = offset.y.toDp()
-                                                        )
+
+                            Box {
+                                if (isGroupChat && !message.isOutgoing) {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(bottom = 2.sdp)
+                                            .pointerInput(message.id) {
+                                                detectTapGestures(
+                                                    onLongPress = { offset ->
+                                                        with(density) {
+                                                            contextMenuOffset = DpOffset(
+                                                                x = offset.x.toDp(),
+                                                                y = offset.y.toDp()
+                                                            )
+                                                        }
+                                                        contextMenuMessage = message
                                                     }
-                                                    contextMenuMessage = message
+                                                )
+                                            },
+                                        horizontalArrangement = Arrangement.Start,
+                                        verticalAlignment = Alignment.Bottom
+                                    ) {
+                                        Box(
+                                            modifier = Modifier
+                                                .size(36.sdp)
+                                        ) {
+                                            AvatarImage(
+                                                mediaId = profile?.avatarMediaId,
+                                                size = 36.sdp,
+                                                fallbackLetter = profile?.username?.take(1)?.uppercase() ?: "?",
+                                                backgroundColor = MaterialTheme.colorScheme.primaryContainer,
+                                                textColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                                                textStyle = TextStyle(fontSize = 14.ssp)
+                                            )
+                                        }
+
+                                        Spacer(modifier = Modifier.width(8.sdp))
+
+                                        Column(horizontalAlignment = Alignment.Start) {
+                                            Text(
+                                                text = profile?.username ?: s.member,
+                                                style = MaterialTheme.typography.labelMedium,
+                                                color = MaterialTheme.colorScheme.primary,
+                                                modifier = Modifier.padding(start = 4.sdp, bottom = 2.sdp)
+                                            )
+
+                                            MessageBubble(
+                                                message          = message,
+                                                myBubbleColor    = myBubbleColor,
+                                                theirBubbleColor = theirBubbleColor,
+                                                myBubbleImage    = myBubbleImage,
+                                                theirBubbleImage = theirBubbleImage,
+                                                searchQuery      = searchQuery,
+                                                isCurrentMatch   = message.id == currentMatchMsgId,
+                                                mediaCache       = mediaCache,
+                                                onLoadMedia      = { id, meta -> viewModel.loadMedia(id, meta) },
+                                                globalAudioPlayer = globalAudioPlayer,
+                                                chatName         = chatName,
+                                                replyToMessage   = replyToMessage,
+                                                replyToSenderName = replyToSenderName,
+                                                onReplyClick     = replyToMessage?.let { replied ->
+                                                    {
+                                                        val idx = chatItems.indexOfFirst { item ->
+                                                            item.allMessages.any { it.serverId == replied.serverId }
+                                                        }
+                                                        if (idx >= 0) {
+                                                            coroutineScope.launch { listState.animateScrollToItem(idx) }
+                                                        }
+                                                    }
+                                                }
+                                            )
+                                        }
+                                    }
+                                } else {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .pointerInput(message.id) {
+                                                detectTapGestures(
+                                                    onLongPress = { offset ->
+                                                        with(density) {
+                                                            contextMenuOffset = DpOffset(
+                                                                x = offset.x.toDp(),
+                                                                y = offset.y.toDp()
+                                                            )
+                                                        }
+                                                        contextMenuMessage = message
+                                                    }
+                                                )
+                                            }
+                                    ) {
+                                        MessageBubble(
+                                            message          = message,
+                                            myBubbleColor    = myBubbleColor,
+                                            theirBubbleColor = theirBubbleColor,
+                                            myBubbleImage    = myBubbleImage,
+                                            theirBubbleImage = theirBubbleImage,
+                                            searchQuery      = searchQuery,
+                                            isCurrentMatch   = message.id == currentMatchMsgId,
+                                            mediaCache       = mediaCache,
+                                            onLoadMedia      = { id, meta -> viewModel.loadMedia(id, meta) },
+                                            globalAudioPlayer = globalAudioPlayer,
+                                            chatName         = chatName,
+                                            replyToMessage   = replyToMessage,
+                                            replyToSenderName = replyToSenderName,
+                                            onReplyClick     = replyToMessage?.let { replied ->
+                                                {
+                                                    val idx = chatItems.indexOfFirst { item ->
+                                                        item.allMessages.any { it.serverId == replied.serverId }
+                                                    }
+                                                    if (idx >= 0) {
+                                                        coroutineScope.launch { listState.animateScrollToItem(idx) }
+                                                    }
                                                 }
                                             }
                                         )
                                     }
-                            ) {
-                                MessageBubble(
-                                    message          = message,
-                                    myBubbleColor    = myBubbleColor,
-                                    theirBubbleColor = theirBubbleColor,
-                                    searchQuery      = searchQuery,
-                                    isCurrentMatch   = message.id == currentMatchMsgId,
-                                    mediaCache       = mediaCache,
-                                    onLoadMedia      = { id, meta -> viewModel.loadMedia(id, meta) },
-                                    globalAudioPlayer = globalAudioPlayer,
-                                    chatName         = chatName,
-                                    replyToMessage   = replyToMessage,
-                                    replyToSenderName = replyToSenderName,
-                                    onReplyClick     = replyToMessage?.let { replied ->
-                                        {
-                                            val idx = messages.indexOfFirst { it.serverId == replied.serverId }
-                                            if (idx >= 0) coroutineScope.launch { listState.animateScrollToItem(idx) }
-                                        }
+                                }
+
+                                DropdownMenu(
+                                    expanded = contextMenuMessage?.id == message.id,
+                                    onDismissRequest = { contextMenuMessage = null },
+                                    offset = contextMenuOffset
+                                ) {
+                                    val isImageMsg = message.type == "image" || message.localPreviewBytes != null
+                                    val hasText = message.text.isNotBlank() && message.type != "voice"
+
+                                    if (isImageMsg) {
+                                        DropdownMenuItem(
+                                            text = { Text(s.saveToGallery) },
+                                            leadingIcon = { Icon(Icons.Default.Download, null) },
+                                            onClick = {
+                                                val mediaId = message.mediaId
+                                                contextMenuMessage = null
+                                                if (mediaId != null) {
+                                                    val bytes = mediaCache[mediaId]
+                                                    if (bytes != null) {
+                                                        coroutineScope.launch {
+                                                            saveImageToGallery(bytes, "memegram_$mediaId.jpg")
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        )
                                     }
-                                )
+
+                                    if (hasText) {
+                                        DropdownMenuItem(
+                                            text = { Text(s.copyText) },
+                                            leadingIcon = { Icon(Icons.Default.ContentCopy, null) },
+                                            onClick = {
+                                                clipboardManager.setText(AnnotatedString(message.text))
+                                                contextMenuMessage = null
+                                            }
+                                        )
+                                    }
+
+                                    DropdownMenuItem(
+                                        text = { Text(s.reply) },
+                                        leadingIcon = { Icon(Icons.AutoMirrored.Filled.Reply, null) },
+                                        onClick = {
+                                            viewModel.setReplyTo(message)
+                                            contextMenuMessage = null
+                                        }
+                                    )
+
+                                    DropdownMenuItem(
+                                        text = { Text(s.deleteForAll, color = MaterialTheme.colorScheme.error) },
+                                        leadingIcon = { Icon(Icons.Default.Delete, null, tint = MaterialTheme.colorScheme.error) },
+                                        onClick = {
+                                            messagesToDelete = listOf(message)
+                                            contextMenuMessage = null
+                                        }
+                                    )
+                                }
                             }
                         }
 
-                        DropdownMenu(
-                            expanded = contextMenuMessage?.id == message.id,
-                            onDismissRequest = { contextMenuMessage = null },
-                            offset = contextMenuOffset
-                        ) {
-                            val isImageMsg = message.type == "image" || message.localPreviewBytes != null
-                            val hasText = message.text.isNotBlank() && message.type != "voice"
+                        is ChatItem.Album -> {
+                            val albumMessages = chatItem.messages
+                            val firstMessage = albumMessages.first()
+                            val isOut = firstMessage.isOutgoing
+                            val senderId = messageSenders[firstMessage.serverId]
+                            val profile = memberProfiles[senderId]
 
-                            if (isImageMsg) {
-                                DropdownMenuItem(
-                                    text = { Text(s.saveToGallery) },
-                                    leadingIcon = { Icon(Icons.Default.Download, null) },
-                                    onClick = {
-                                        val mediaId = message.mediaId
-                                        contextMenuMessage = null
-                                        if (mediaId != null) {
-                                            val bytes = mediaCache[mediaId]
-                                            if (bytes != null) {
-                                                coroutineScope.launch {
-                                                    saveImageToGallery(bytes, "memegram_$mediaId.jpg")
+                            var showAlbumContextMenu by remember { mutableStateOf(false) }
+                            var albumContextOffset by remember { mutableStateOf(DpOffset.Zero) }
+
+                            Box {
+                                if (isGroupChat && !isOut) {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(bottom = 2.sdp)
+                                            .pointerInput(chatItem.groupId) {
+                                                detectTapGestures(
+                                                    onLongPress = { offset ->
+                                                        with(density) {
+                                                            albumContextOffset = DpOffset(
+                                                                x = offset.x.toDp(),
+                                                                y = offset.y.toDp()
+                                                            )
+                                                        }
+                                                        showAlbumContextMenu = true
+                                                    }
+                                                )
+                                            },
+                                        horizontalArrangement = Arrangement.Start,
+                                        verticalAlignment = Alignment.Bottom
+                                    ) {
+                                        Box(modifier = Modifier.size(36.sdp)) {
+                                            AvatarImage(
+                                                mediaId = profile?.avatarMediaId,
+                                                size = 36.sdp,
+                                                fallbackLetter = profile?.username?.take(1)?.uppercase() ?: "?",
+                                                backgroundColor = MaterialTheme.colorScheme.primaryContainer,
+                                                textColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                                                textStyle = TextStyle(fontSize = 14.ssp)
+                                            )
+                                        }
+
+                                        Spacer(modifier = Modifier.width(8.sdp))
+
+                                        Column(horizontalAlignment = Alignment.Start) {
+                                            Text(
+                                                text = profile?.username ?: s.member,
+                                                style = MaterialTheme.typography.labelMedium,
+                                                color = MaterialTheme.colorScheme.primary,
+                                                modifier = Modifier.padding(start = 4.sdp, bottom = 2.sdp)
+                                            )
+
+                                            AlbumBubble(
+                                                albumMessages = albumMessages,
+                                                isOutgoing = isOut,
+                                                myBubbleColor = myBubbleColor,
+                                                theirBubbleColor = theirBubbleColor,
+                                                myBubbleImage = myBubbleImage,
+                                                theirBubbleImage = theirBubbleImage,
+                                                mediaCache = mediaCache,
+                                                onLoadMedia = { id, meta -> viewModel.loadMedia(id, meta) },
+                                                searchQuery = searchQuery,
+                                                isCurrentMatch = albumMessages.any { it.id == currentMatchMsgId }
+                                            )
+                                        }
+                                    }
+                                } else {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .pointerInput(chatItem.groupId) {
+                                                detectTapGestures(
+                                                    onLongPress = { offset ->
+                                                        with(density) {
+                                                            albumContextOffset = DpOffset(
+                                                                x = offset.x.toDp(),
+                                                                y = offset.y.toDp()
+                                                            )
+                                                        }
+                                                        showAlbumContextMenu = true
+                                                    }
+                                                )
+                                            }
+                                    ) {
+                                        AlbumBubble(
+                                            albumMessages = albumMessages,
+                                            isOutgoing = isOut,
+                                            myBubbleColor = myBubbleColor,
+                                            theirBubbleColor = theirBubbleColor,
+                                            myBubbleImage = myBubbleImage,
+                                            theirBubbleImage = theirBubbleImage,
+                                            mediaCache = mediaCache,
+                                            onLoadMedia = { id, meta -> viewModel.loadMedia(id, meta) },
+                                            searchQuery = searchQuery,
+                                            isCurrentMatch = albumMessages.any { it.id == currentMatchMsgId }
+                                        )
+                                    }
+                                }
+
+                                DropdownMenu(
+                                    expanded = showAlbumContextMenu,
+                                    onDismissRequest = { showAlbumContextMenu = false },
+                                    offset = albumContextOffset
+                                ) {
+                                    DropdownMenuItem(
+                                        text = { Text(s.saveAllNPhotos(albumMessages.size)) },
+                                        leadingIcon = { Icon(Icons.Default.Download, null) },
+                                        onClick = {
+                                            showAlbumContextMenu = false
+                                            coroutineScope.launch {
+                                                albumMessages.forEach { msg ->
+                                                    val mid = msg.mediaId
+                                                    if (mid != null) {
+                                                        val bytes = mediaCache[mid]
+                                                        if (bytes != null) {
+                                                            saveImageToGallery(bytes, "memegram_$mid.jpg")
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }
+                                    )
+
+                                    val captionMsg = albumMessages.firstOrNull { it.text.isNotBlank() }
+                                    if (captionMsg != null) {
+                                        DropdownMenuItem(
+                                            text = { Text(s.copyText) },
+                                            leadingIcon = { Icon(Icons.Default.ContentCopy, null) },
+                                            onClick = {
+                                                clipboardManager.setText(AnnotatedString(captionMsg.text))
+                                                showAlbumContextMenu = false
+                                            }
+                                        )
                                     }
-                                )
-                            }
 
-                            if (hasText) {
-                                DropdownMenuItem(
-                                    text = { Text(s.copyText) },
-                                    leadingIcon = { Icon(Icons.Default.ContentCopy, null) },
-                                    onClick = {
-                                        clipboardManager.setText(AnnotatedString(message.text))
-                                        contextMenuMessage = null
-                                    }
-                                )
-                            }
+                                    DropdownMenuItem(
+                                        text = { Text(s.reply) },
+                                        leadingIcon = { Icon(Icons.AutoMirrored.Filled.Reply, null) },
+                                        onClick = {
+                                            viewModel.setReplyTo(firstMessage)
+                                            showAlbumContextMenu = false
+                                        }
+                                    )
 
-                            DropdownMenuItem(
-                                text = { Text(s.reply) },
-                                leadingIcon = { Icon(Icons.AutoMirrored.Filled.Reply, null) },
-                                onClick = {
-                                    viewModel.setReplyTo(message)
-                                    contextMenuMessage = null
+                                    DropdownMenuItem(
+                                        text = { Text(s.deleteForAll, color = MaterialTheme.colorScheme.error) },
+                                        leadingIcon = { Icon(Icons.Default.Delete, null, tint = MaterialTheme.colorScheme.error) },
+                                        onClick = {
+                                            messagesToDelete = albumMessages
+                                            showAlbumContextMenu = false
+                                        }
+                                    )
                                 }
-                            )
-
-                            DropdownMenuItem(
-                                text = { Text(s.deleteForAll, color = MaterialTheme.colorScheme.error) },
-                                leadingIcon = { Icon(Icons.Default.Delete, null, tint = MaterialTheme.colorScheme.error) },
-                                onClick = {
-                                    messageToDelete = message
-                                    contextMenuMessage = null
-                                }
-                            )
+                            }
                         }
                     }
                 }
@@ -940,7 +1221,7 @@ fun GalleryGridItem(
     Box(
         modifier = Modifier
             .aspectRatio(1f)
-            .clip(RoundedCornerShape(2.dp))
+            .clip(RoundedCornerShape(2.sdp))
             .clickable { onClick() }
     ) {
         if (bitmap != null) {
@@ -960,19 +1241,19 @@ fun GalleryGridItem(
 
         Box(
             modifier = Modifier
-                .padding(5.dp)
-                .size(24.dp)
+                .padding(5.sdp)
+                .size(24.sdp)
                 .clip(CircleShape)
                 .background(
                     if (isSelected) MaterialTheme.colorScheme.primary
                     else Color.Black.copy(alpha = 0.35f)
                 )
-                .border(1.5.dp, Color.White, CircleShape)
+                .border(1.5.sdp, Color.White, CircleShape)
                 .align(Alignment.TopEnd),
             contentAlignment = Alignment.Center
         ) {
             if (isSelected) {
-                Text(selNumber.toString(), color = Color.White, fontSize = 11.sp)
+                Text(selNumber.toString(), color = Color.White, fontSize = 11.ssp)
             }
         }
     }
@@ -994,8 +1275,8 @@ fun AttachmentThumbnail(item: AttachItem, onRemove: () -> Unit) {
 
     Box(
         modifier = Modifier
-            .size(72.dp)
-            .clip(RoundedCornerShape(8.dp))
+            .size(72.sdp)
+            .clip(RoundedCornerShape(8.sdp))
             .background(MaterialTheme.colorScheme.surfaceVariant)
     ) {
         if (bitmap != null) {
@@ -1011,20 +1292,20 @@ fun AttachmentThumbnail(item: AttachItem, onRemove: () -> Unit) {
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {
-                Icon(Icons.AutoMirrored.Filled.InsertDriveFile, null, modifier = Modifier.size(28.dp), tint = MaterialTheme.colorScheme.primary)
-                Text(item.name, fontSize = 9.sp, maxLines = 2, overflow = TextOverflow.Ellipsis, modifier = Modifier.padding(horizontal = 4.dp))
+                Icon(Icons.AutoMirrored.Filled.InsertDriveFile, null, modifier = Modifier.size(28.sdp), tint = MaterialTheme.colorScheme.primary)
+                Text(item.name, fontSize = 9.ssp, maxLines = 2, overflow = TextOverflow.Ellipsis, modifier = Modifier.padding(horizontal = 4.sdp))
             }
         }
         Box(
             modifier = Modifier
-                .size(20.dp)
+                .size(20.sdp)
                 .clip(CircleShape)
                 .background(Color.Black.copy(alpha = 0.55f))
                 .align(Alignment.TopEnd)
                 .clickable { onRemove() },
             contentAlignment = Alignment.Center
         ) {
-            Icon(Icons.Default.Close, null, tint = Color.White, modifier = Modifier.size(12.dp))
+            Icon(Icons.Default.Close, null, tint = Color.White, modifier = Modifier.size(12.sdp))
         }
     }
 }
@@ -1043,6 +1324,8 @@ fun MessageBubble(
     message: Message,
     myBubbleColor: Color,
     theirBubbleColor: Color,
+    myBubbleImage: ByteArray? = null,
+    theirBubbleImage: ByteArray? = null,
     searchQuery: String = "",
     isCurrentMatch: Boolean = false,
     mediaCache: Map<String, ByteArray> = emptyMap(),
@@ -1057,7 +1340,13 @@ fun MessageBubble(
     val s = LocalStrings.current
     val bubbleColor = if (isCurrentMatch) MaterialTheme.colorScheme.tertiary
     else if (isOut) myBubbleColor else theirBubbleColor
-    val textColor   = if (bubbleColor.luminance() > 0.5f) Color.Black else Color.White
+    val bubbleImageBytes = if (isCurrentMatch) null
+    else if (isOut) myBubbleImage else theirBubbleImage
+    val bubbleImageBitmap = remember(bubbleImageBytes) {
+        bubbleImageBytes?.let { runCatching { it.decodeToImageBitmap() }.getOrNull() }
+    }
+    val textColor   = if (bubbleImageBitmap != null) Color.White
+    else if (bubbleColor.luminance() > 0.5f) Color.Black else Color.White
     val timeText    = remember(message.timestamp) { formatMessageTime(message.timestamp) }
     val timeColor   = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
 
@@ -1083,41 +1372,51 @@ fun MessageBubble(
         verticalAlignment     = Alignment.Bottom
     ) {
         if (isOut && timeText.isNotEmpty()) {
-            Text(timeText, color = timeColor, fontSize = 11.sp,
-                modifier = Modifier.padding(end = 4.dp, bottom = 4.dp))
+            Text(timeText, color = timeColor, fontSize = 11.ssp,
+                modifier = Modifier.padding(end = 4.sdp, bottom = 4.sdp))
         }
 
         Box(
             modifier = Modifier
-                .widthIn(max = 280.dp)
+                .widthIn(max = 280.sdp)
                 .clip(RoundedCornerShape(
-                    topStart    = 16.dp, topEnd = 16.dp,
-                    bottomStart = if (isOut) 16.dp else 4.dp,
-                    bottomEnd   = if (isOut) 4.dp else 16.dp
+                    topStart    = 16.sdp, topEnd = 16.sdp,
+                    bottomStart = if (isOut) 16.sdp else 4.sdp,
+                    bottomEnd   = if (isOut) 4.sdp else 16.sdp
                 ))
                 .background(bubbleColor)
-                .padding(
-                    horizontal = if (isImageMsg && !hasText) 0.dp else 12.dp,
-                    vertical   = if (isImageMsg && !hasText) 0.dp else 8.dp
-                )
         ) {
+            if (bubbleImageBitmap != null) {
+                Image(
+                    bitmap = bubbleImageBitmap,
+                    contentDescription = null,
+                    modifier = Modifier.matchParentSize(),
+                    contentScale = ContentScale.Crop
+                )
+            }
+            Box(
+                modifier = Modifier.padding(
+                    horizontal = if (isImageMsg && !hasText) 0.sdp else 12.sdp,
+                    vertical   = if (isImageMsg && !hasText) 0.sdp else 8.sdp
+                )
+            ) {
             Column {
                 if (replyToMessage != null) {
                     Box(
                         modifier = Modifier
                             .padding(
-                                start = if (isImageMsg && !hasText) 8.dp else 0.dp,
-                                end = if (isImageMsg && !hasText) 8.dp else 0.dp,
-                                top = if (isImageMsg && !hasText) 8.dp else 0.dp,
-                                bottom = 4.dp
+                                start = if (isImageMsg && !hasText) 8.sdp else 0.sdp,
+                                end = if (isImageMsg && !hasText) 8.sdp else 0.sdp,
+                                top = if (isImageMsg && !hasText) 8.sdp else 0.sdp,
+                                bottom = 4.sdp
                             )
-                            .clip(RoundedCornerShape(8.dp))
+                            .clip(RoundedCornerShape(8.sdp))
                             .background(textColor.copy(alpha = 0.1f))
                             .then(
                                 if (onReplyClick != null) Modifier.clickable { onReplyClick() }
                                 else Modifier
                             )
-                            .padding(horizontal = 8.dp, vertical = 6.dp)
+                            .padding(horizontal = 8.sdp, vertical = 6.sdp)
                     ) {
                         Column {
                             Text(
@@ -1173,11 +1472,11 @@ fun MessageBubble(
 
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp).width(200.dp)
+                        modifier = Modifier.padding(horizontal = 12.sdp, vertical = 8.sdp).width(200.sdp)
                     ) {
                         Box(
                             modifier = Modifier
-                                .size(44.dp)
+                                .size(44.sdp)
                                 .clip(CircleShape)
                                 .background(textColor.copy(alpha = 0.15f))
                                 .clickable {
@@ -1202,24 +1501,24 @@ fun MessageBubble(
                             contentAlignment = Alignment.Center
                         ) {
                             if (cachedBytes == null) {
-                                CircularProgressIndicator(modifier = Modifier.size(20.dp), color = textColor, strokeWidth = 2.dp)
+                                CircularProgressIndicator(modifier = Modifier.size(20.sdp), color = textColor, strokeWidth = 2.sdp)
                             } else {
                                 Icon(if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow, null, tint = textColor)
                             }
                         }
 
-                        Spacer(modifier = Modifier.width(12.dp))
+                        Spacer(modifier = Modifier.width(12.sdp))
 
                         Column(modifier = Modifier.weight(1f)) {
                             VoiceWaveform(
                                 amplitudes = parsedAmps.ifEmpty { List(30) { 1 } },
                                 progress = currentProgress,
-                                modifier = Modifier.fillMaxWidth().height(24.dp),
+                                modifier = Modifier.fillMaxWidth().height(24.sdp),
                                 playedColor = textColor,
                                 unplayedColor = textColor.copy(alpha = 0.3f)
                             )
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Text(displayTime, color = textColor.copy(alpha = 0.7f), fontSize = 11.sp)
+                            Spacer(modifier = Modifier.height(4.sdp))
+                            Text(displayTime, color = textColor.copy(alpha = 0.7f), fontSize = 11.ssp)
                         }
                     }
                 } else if (isImageMsg) {
@@ -1230,41 +1529,41 @@ fun MessageBubble(
                             contentScale       = ContentScale.Crop,
                             modifier           = Modifier
                                 .fillMaxWidth()
-                                .heightIn(max = 240.dp)
+                                .heightIn(max = 240.sdp)
                                 .clip(RoundedCornerShape(
-                                    topStart    = 16.dp, topEnd = 16.dp,
-                                    bottomStart = if (!hasText && isOut) 16.dp else if (!hasText) 4.dp else 0.dp,
-                                    bottomEnd   = if (!hasText && isOut) 4.dp else if (!hasText) 16.dp else 0.dp
+                                    topStart    = 16.sdp, topEnd = 16.sdp,
+                                    bottomStart = if (!hasText && isOut) 16.sdp else if (!hasText) 4.sdp else 0.sdp,
+                                    bottomEnd   = if (!hasText && isOut) 4.sdp else if (!hasText) 16.sdp else 0.sdp
                                 ))
                         )
                     } else {
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .height(160.dp)
+                                .height(160.sdp)
                                 .background(bubbleColor.copy(alpha = 0.6f)),
                             contentAlignment = Alignment.Center
                         ) {
                             if (message.status == MessageStatus.SENDING) {
                                 CircularProgressIndicator(
-                                    modifier = Modifier.size(32.dp),
+                                    modifier = Modifier.size(32.sdp),
                                     color = textColor
                                 )
                             } else {
                                 Icon(
                                     Icons.Default.Image,
                                     contentDescription = null,
-                                    modifier = Modifier.size(40.dp),
+                                    modifier = Modifier.size(40.sdp),
                                     tint = textColor.copy(alpha = 0.5f)
                                 )
                             }
                         }
                     }
-                    if (hasText) Spacer(Modifier.height(6.dp))
+                    if (hasText) Spacer(Modifier.height(6.sdp))
                 }
 
                 if (hasText) {
-                    val textMod = if (isImageMsg) Modifier.padding(horizontal = 12.dp, vertical = 8.dp) else Modifier
+                    val textMod = if (isImageMsg) Modifier.padding(horizontal = 12.sdp, vertical = 8.sdp) else Modifier
                     val annotated = buildAnnotatedString {
                         if (searchQuery.isBlank()) {
                             append(message.text)
@@ -1289,21 +1588,22 @@ fun MessageBubble(
 
                 if (isOut && message.status != MessageStatus.SENT) {
                     val iconMod = if (isImageMsg)
-                        Modifier.padding(end = 8.dp, bottom = 4.dp).align(Alignment.End)
+                        Modifier.padding(end = 8.sdp, bottom = 4.sdp).align(Alignment.End)
                     else Modifier.align(Alignment.End)
                     Text(
                         text     = if (message.status == MessageStatus.SENDING) "⏳" else "❌",
-                        fontSize = 11.sp,
+                        fontSize = 11.ssp,
                         color    = textColor.copy(alpha = 0.6f),
                         modifier = iconMod
                     )
                 }
             }
+            }
         }
 
         if (!isOut && timeText.isNotEmpty()) {
-            Text(timeText, color = timeColor, fontSize = 11.sp,
-                modifier = Modifier.padding(start = 4.dp, bottom = 4.dp))
+            Text(timeText, color = timeColor, fontSize = 11.ssp,
+                modifier = Modifier.padding(start = 4.sdp, bottom = 4.sdp))
         }
     }
 }
@@ -1316,16 +1616,19 @@ fun VoiceWaveform(
     playedColor: Color,
     unplayedColor: Color
 ) {
+    val barWidthDp = 3.sdp
+    val spacingDp = 2.sdp
+    val minBarHeightDp = 4.sdp
     Canvas(modifier = modifier) {
-        val barWidth = 3.dp.toPx()
-        val spacing = 2.dp.toPx()
+        val barWidth = barWidthDp.toPx()
+        val spacing = spacingDp.toPx()
         val maxBars = (size.width / (barWidth + spacing)).toInt()
 
         val displayAmps = if (amplitudes.size > maxBars) amplitudes.takeLast(maxBars) else amplitudes
         val startX = 0f
 
         displayAmps.forEachIndexed { index, amp ->
-            val barHeight = maxOf(4.dp.toPx(), (amp / 9f) * size.height)
+            val barHeight = maxOf(minBarHeightDp.toPx(), (amp / 9f) * size.height)
             val x = startX + index * (barWidth + spacing)
             val isPlayed = (index.toFloat() / displayAmps.size) <= progress
 
@@ -1335,6 +1638,427 @@ fun VoiceWaveform(
                 size = androidx.compose.ui.geometry.Size(barWidth, barHeight),
                 cornerRadius = androidx.compose.ui.geometry.CornerRadius(barWidth / 2, barWidth / 2)
             )
+        }
+    }
+}
+
+sealed class ChatItem {
+    data class Single(val message: Message) : ChatItem()
+    data class Album(val messages: List<Message>, val groupId: String) : ChatItem()
+
+    val allMessages: List<Message>
+        get() = when (this) {
+            is Single -> listOf(message)
+            is Album -> messages
+        }
+
+    val stableKey: Int
+        get() = when (this) {
+            is Single -> message.id
+            is Album -> groupId.hashCode()
+        }
+}
+
+fun groupMessages(messages: List<Message>): List<ChatItem> {
+    if (messages.isEmpty()) return emptyList()
+    val result = mutableListOf<ChatItem>()
+    val buffer = mutableListOf<Message>()
+    var currentGroupId: String? = null
+
+    fun flushBuffer() {
+        if (buffer.isEmpty()) return
+        if (buffer.size == 1) {
+            result += ChatItem.Single(buffer.first())
+        } else {
+            result += ChatItem.Album(buffer.toList(), currentGroupId!!)
+        }
+        buffer.clear()
+        currentGroupId = null
+    }
+
+    for (msg in messages) {
+        val gid = msg.groupId
+        if (gid != null && msg.type == "image") {
+            if (gid == currentGroupId) {
+                buffer += msg
+            } else {
+                flushBuffer()
+                currentGroupId = gid
+                buffer += msg
+            }
+        } else {
+            flushBuffer()
+            result += ChatItem.Single(msg)
+        }
+    }
+    flushBuffer()
+    return result
+}
+
+@Composable
+fun AlbumBubble(
+    albumMessages: List<Message>,
+    isOutgoing: Boolean,
+    myBubbleColor: Color,
+    theirBubbleColor: Color,
+    myBubbleImage: ByteArray? = null,
+    theirBubbleImage: ByteArray? = null,
+    mediaCache: Map<String, ByteArray> = emptyMap(),
+    onLoadMedia: (String, String?) -> Unit = { _, _ -> },
+    searchQuery: String = "",
+    isCurrentMatch: Boolean = false
+) {
+    val s = LocalStrings.current
+    val bubbleColor = if (isCurrentMatch) MaterialTheme.colorScheme.tertiary
+    else if (isOutgoing) myBubbleColor else theirBubbleColor
+    val bubbleImageBytes = if (isCurrentMatch) null
+    else if (isOutgoing) myBubbleImage else theirBubbleImage
+    val bubbleImageBitmap = remember(bubbleImageBytes) {
+        bubbleImageBytes?.let { runCatching { it.decodeToImageBitmap() }.getOrNull() }
+    }
+    val textColor = if (bubbleImageBitmap != null) Color.White
+    else if (bubbleColor.luminance() > 0.5f) Color.Black else Color.White
+    val timeText = remember(albumMessages.lastOrNull()?.timestamp) {
+        formatMessageTime(albumMessages.lastOrNull()?.timestamp ?: 0L)
+    }
+    val timeColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+
+    val caption = albumMessages.firstOrNull { it.text.isNotBlank() && it.status != MessageStatus.FAILED }?.text
+
+    val photoBitmaps = albumMessages.map { msg ->
+        val cachedBytes = msg.mediaId?.let { mediaCache[it] }
+        val bitmap = remember(msg.localPreviewBytes, cachedBytes) {
+            (cachedBytes ?: msg.localPreviewBytes)?.let {
+                runCatching { it.decodeToImageBitmap() }.getOrNull()
+            }
+        }
+        val mediaId = msg.mediaId
+        val encMeta = msg.encryptionMetadata
+        LaunchedEffect(mediaId) {
+            if (mediaId != null && cachedBytes == null && msg.localPreviewBytes == null) {
+                onLoadMedia(mediaId, encMeta)
+            }
+        }
+        bitmap
+    }
+
+    val hasCaption = !caption.isNullOrBlank()
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = if (isOutgoing) Arrangement.End else Arrangement.Start,
+        verticalAlignment = Alignment.Bottom
+    ) {
+        if (isOutgoing && timeText.isNotEmpty()) {
+            Text(
+                timeText, color = timeColor, fontSize = 11.ssp,
+                modifier = Modifier.padding(end = 4.sdp, bottom = 4.sdp)
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .widthIn(max = 280.sdp)
+                .clip(
+                    RoundedCornerShape(
+                        topStart = 16.sdp, topEnd = 16.sdp,
+                        bottomStart = if (isOutgoing) 16.sdp else 4.sdp,
+                        bottomEnd = if (isOutgoing) 4.sdp else 16.sdp
+                    )
+                )
+                .background(bubbleColor)
+        ) {
+            if (bubbleImageBitmap != null) {
+                Image(
+                    bitmap = bubbleImageBitmap,
+                    contentDescription = null,
+                    modifier = Modifier.matchParentSize(),
+                    contentScale = ContentScale.Crop
+                )
+            }
+
+            Column {
+                AlbumPhotoGrid(
+                    bitmaps = photoBitmaps,
+                    messages = albumMessages,
+                    bubbleColor = bubbleColor,
+                    textColor = textColor,
+                    hasCaption = hasCaption,
+                    isOutgoing = isOutgoing
+                )
+
+                if (hasCaption) {
+                    val annotated = buildAnnotatedString {
+                        if (searchQuery.isBlank()) {
+                            append(caption!!)
+                        } else {
+                            val lower = caption!!.lowercase()
+                            val lowerQ = searchQuery.lowercase()
+                            var pos = 0
+                            while (pos < caption.length) {
+                                val idx = lower.indexOf(lowerQ, pos)
+                                if (idx == -1) { append(caption.substring(pos)); break }
+                                append(caption.substring(pos, idx))
+                                withStyle(SpanStyle(background = Color(0xFFFFD60A))) {
+                                    append(caption.substring(idx, idx + searchQuery.length))
+                                }
+                                pos = idx + searchQuery.length
+                            }
+                        }
+                    }
+                    Text(
+                        text = annotated,
+                        color = textColor,
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(horizontal = 12.sdp, vertical = 8.sdp)
+                    )
+                }
+
+                if (isOutgoing) {
+                    val anyNotSent = albumMessages.any { it.status != MessageStatus.SENT }
+                    if (anyNotSent) {
+                        val anySending = albumMessages.any { it.status == MessageStatus.SENDING }
+                        Text(
+                            text = if (anySending) "⏳" else "❌",
+                            fontSize = 11.ssp,
+                            color = textColor.copy(alpha = 0.6f),
+                            modifier = Modifier
+                                .padding(end = 8.sdp, bottom = 4.sdp)
+                                .align(Alignment.End)
+                        )
+                    }
+                }
+            }
+        }
+
+        if (!isOutgoing && timeText.isNotEmpty()) {
+            Text(
+                timeText, color = timeColor, fontSize = 11.ssp,
+                modifier = Modifier.padding(start = 4.sdp, bottom = 4.sdp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun AlbumPhotoGrid(
+    bitmaps: List<ImageBitmap?>,
+    messages: List<Message>,
+    bubbleColor: Color,
+    textColor: Color,
+    hasCaption: Boolean,
+    isOutgoing: Boolean
+) {
+    val spacing = 2.sdp
+    val count = bitmaps.size
+
+    val topStart = 16.sdp
+    val topEnd = 16.sdp
+    val bottomStart = if (!hasCaption && isOutgoing) 16.sdp else if (!hasCaption) 4.sdp else 0.sdp
+    val bottomEnd = if (!hasCaption && isOutgoing) 4.sdp else if (!hasCaption) 16.sdp else 0.sdp
+
+    when (count) {
+        0 -> {}
+        1 -> {
+            AlbumPhotoCell(
+                bitmap = bitmaps[0],
+                message = messages[0],
+                bubbleColor = bubbleColor,
+                textColor = textColor,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 240.sdp)
+                    .clip(
+                        RoundedCornerShape(
+                            topStart = topStart, topEnd = topEnd,
+                            bottomStart = bottomStart, bottomEnd = bottomEnd
+                        )
+                    )
+            )
+        }
+        2 -> {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(spacing)) {
+                AlbumPhotoCell(
+                    bitmap = bitmaps[0], message = messages[0],
+                    bubbleColor = bubbleColor, textColor = textColor,
+                    modifier = Modifier
+                        .weight(1f)
+                        .aspectRatio(0.8f)
+                        .clip(RoundedCornerShape(topStart = topStart, bottomStart = bottomStart))
+                )
+                AlbumPhotoCell(
+                    bitmap = bitmaps[1], message = messages[1],
+                    bubbleColor = bubbleColor, textColor = textColor,
+                    modifier = Modifier
+                        .weight(1f)
+                        .aspectRatio(0.8f)
+                        .clip(RoundedCornerShape(topEnd = topEnd, bottomEnd = bottomEnd))
+                )
+            }
+        }
+        3 -> {
+            Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(spacing)
+                ) {
+                    AlbumPhotoCell(
+                        bitmap = bitmaps[0], message = messages[0],
+                        bubbleColor = bubbleColor, textColor = textColor,
+                        modifier = Modifier.weight(1f).aspectRatio(1f)
+                            .clip(RoundedCornerShape(topStart = topStart))
+                    )
+                    AlbumPhotoCell(
+                        bitmap = bitmaps[1], message = messages[1],
+                        bubbleColor = bubbleColor, textColor = textColor,
+                        modifier = Modifier.weight(1f).aspectRatio(1f)
+                            .clip(RoundedCornerShape(topEnd = topEnd))
+                    )
+                }
+                AlbumPhotoCell(
+                    bitmap = bitmaps[2], message = messages[2],
+                    bubbleColor = bubbleColor, textColor = textColor,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(2f)
+                        .clip(RoundedCornerShape(bottomStart = bottomStart, bottomEnd = bottomEnd))
+                )
+            }
+        }
+        4 -> {
+            Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(spacing)
+                ) {
+                    AlbumPhotoCell(
+                        bitmap = bitmaps[0], message = messages[0],
+                        bubbleColor = bubbleColor, textColor = textColor,
+                        modifier = Modifier.weight(1f).aspectRatio(1f)
+                            .clip(RoundedCornerShape(topStart = topStart))
+                    )
+                    AlbumPhotoCell(
+                        bitmap = bitmaps[1], message = messages[1],
+                        bubbleColor = bubbleColor, textColor = textColor,
+                        modifier = Modifier.weight(1f).aspectRatio(1f)
+                            .clip(RoundedCornerShape(topEnd = topEnd))
+                    )
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(spacing)
+                ) {
+                    AlbumPhotoCell(
+                        bitmap = bitmaps[2], message = messages[2],
+                        bubbleColor = bubbleColor, textColor = textColor,
+                        modifier = Modifier.weight(1f).aspectRatio(1f)
+                            .clip(RoundedCornerShape(bottomStart = bottomStart))
+                    )
+                    AlbumPhotoCell(
+                        bitmap = bitmaps[3], message = messages[3],
+                        bubbleColor = bubbleColor, textColor = textColor,
+                        modifier = Modifier.weight(1f).aspectRatio(1f)
+                            .clip(RoundedCornerShape(bottomEnd = bottomEnd))
+                    )
+                }
+            }
+        }
+        else -> {
+            Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
+                val rows = bitmaps.chunked(2)
+                rows.forEachIndexed { rowIdx, rowBitmaps ->
+                    val isFirstRow = rowIdx == 0
+                    val isLastRow = rowIdx == rows.lastIndex
+                    if (rowBitmaps.size == 2) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(spacing)
+                        ) {
+                            val msgIdx = rowIdx * 2
+                            AlbumPhotoCell(
+                                bitmap = rowBitmaps[0], message = messages[msgIdx],
+                                bubbleColor = bubbleColor, textColor = textColor,
+                                modifier = Modifier.weight(1f).aspectRatio(1f).clip(
+                                    RoundedCornerShape(
+                                        topStart = if (isFirstRow) topStart else 0.sdp,
+                                        bottomStart = if (isLastRow) bottomStart else 0.sdp
+                                    )
+                                )
+                            )
+                            AlbumPhotoCell(
+                                bitmap = rowBitmaps[1], message = messages[msgIdx + 1],
+                                bubbleColor = bubbleColor, textColor = textColor,
+                                modifier = Modifier.weight(1f).aspectRatio(1f).clip(
+                                    RoundedCornerShape(
+                                        topEnd = if (isFirstRow) topEnd else 0.sdp,
+                                        bottomEnd = if (isLastRow) bottomEnd else 0.sdp
+                                    )
+                                )
+                            )
+                        }
+                    } else {
+                        val msgIdx = rowIdx * 2
+                        AlbumPhotoCell(
+                            bitmap = rowBitmaps[0], message = messages[msgIdx],
+                            bubbleColor = bubbleColor, textColor = textColor,
+                            modifier = Modifier.fillMaxWidth().aspectRatio(2f).clip(
+                                RoundedCornerShape(
+                                    bottomStart = bottomStart,
+                                    bottomEnd = bottomEnd
+                                )
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlbumPhotoCell(
+    bitmap: ImageBitmap?,
+    message: Message,
+    bubbleColor: Color,
+    textColor: Color,
+    modifier: Modifier
+) {
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        if (bitmap != null) {
+            Image(
+                bitmap = bitmap,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
+            )
+        } else {
+            Box(
+                modifier = Modifier.fillMaxSize().background(bubbleColor.copy(alpha = 0.6f)),
+                contentAlignment = Alignment.Center
+            ) {
+                if (message.status == MessageStatus.SENDING) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.sdp),
+                        color = textColor,
+                        strokeWidth = 2.sdp
+                    )
+                } else if (message.status != MessageStatus.FAILED) {
+                    Icon(
+                        Icons.Default.Image,
+                        contentDescription = null,
+                        modifier = Modifier.size(28.sdp),
+                        tint = textColor.copy(alpha = 0.5f)
+                    )
+                }
+            }
+        }
+        if (message.status == MessageStatus.FAILED) {
+            Box(
+                modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.4f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text("❌", fontSize = 20.ssp)
+            }
         }
     }
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatViewModel.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatViewModel.kt
@@ -8,6 +8,9 @@ import com.example.memegram.audio.createAudioRecorder
 import com.example.memegram.data.local.SessionManager
 import com.example.memegram.data.models.*
 import com.example.memegram.data.network.ApiService
+import com.russhwolf.settings.Settings
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import com.example.memegram.data.repository.ChatRepository
 import com.example.memegram.mls.MlsManager
 import com.example.memegram.utils.generateUuid
@@ -23,11 +26,14 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.time.Clock
 
+@OptIn(ExperimentalEncodingApi::class)
 class ChatViewModel(
     private val api: ApiService,
     private val sessionManager: SessionManager,
     private val mlsManager: MlsManager,
-    private val chatRepository: ChatRepository
+    private val chatRepository: ChatRepository,
+    private val themePreferences: ThemePreferences,
+    private val settings: Settings
 ) : ViewModel() {
 
     private val _messages = MutableStateFlow<List<Message>>(emptyList())
@@ -45,20 +51,45 @@ class ChatViewModel(
     private val _inputText        = MutableStateFlow("")
     val inputText: StateFlow<String> = _inputText.asStateFlow()
 
-    private val _chatBgColor      = MutableStateFlow(Color(0xFFECECEC))
+    private val _chatBgColor      = MutableStateFlow(
+        themePreferences.getColor("chatbg", ThemePreferences.DefaultChatBg)
+    )
     val chatBgColor: StateFlow<Color> = _chatBgColor.asStateFlow()
 
-    private val _myBubbleColor    = MutableStateFlow(Color(0xFF4CAF50))
+    private val _myBubbleColor    = MutableStateFlow(
+        themePreferences.getColor("mybubble", ThemePreferences.DefaultMyBubble)
+    )
     val myBubbleColor: StateFlow<Color> = _myBubbleColor.asStateFlow()
 
-    private val _theirBubbleColor = MutableStateFlow(Color(0xFFFFFFFF))
+    private val _theirBubbleColor = MutableStateFlow(
+        themePreferences.getColor("theirbubble", ThemePreferences.DefaultTheirBubble)
+    )
     val theirBubbleColor: StateFlow<Color> = _theirBubbleColor.asStateFlow()
+
+    private val _chatBgImage = MutableStateFlow<ByteArray?>(
+        settings.getStringOrNull("appearance_chatbg_image")?.let { runCatching { Base64.decode(it) }.getOrNull() }
+    )
+    val chatBgImage: StateFlow<ByteArray?> = _chatBgImage.asStateFlow()
+
+    private val _myBubbleImage = MutableStateFlow<ByteArray?>(
+        settings.getStringOrNull("appearance_mybubble_image")?.let { runCatching { Base64.decode(it) }.getOrNull() }
+    )
+    val myBubbleImage: StateFlow<ByteArray?> = _myBubbleImage.asStateFlow()
+
+    private val _theirBubbleImage = MutableStateFlow<ByteArray?>(
+        settings.getStringOrNull("appearance_theirbubble_image")?.let { runCatching { Base64.decode(it) }.getOrNull() }
+    )
+    val theirBubbleImage: StateFlow<ByteArray?> = _theirBubbleImage.asStateFlow()
 
     private val _isLoading        = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
     private val _error            = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
+
+    /** Unread count at the moment the chat was opened (from the server). */
+    private val _initialUnreadCount = MutableStateFlow(0)
+    val initialUnreadCount: StateFlow<Int> = _initialUnreadCount.asStateFlow()
 
     var currentConversationId: String? = null
         private set
@@ -119,6 +150,7 @@ class ChatViewModel(
         viewModelScope.launch {
             try {
                 val conv = api.getConversation(conversationId)
+                _initialUnreadCount.value = conv.unreadCount ?: 0
                 val isGroup = conv.type != "direct"
                 _isGroupChat.value = isGroup
 
@@ -187,24 +219,42 @@ class ChatViewModel(
                         }
                     }
 
-                    val (parsedType, parsedMediaId, content) = parseMlsPayload(text)
+                    val parsed = parseMlsPayload(text)
 
                     Message(
                         id           = existing?.id ?: msg.id.hashCode(),
                         serverId     = msg.id,
-                        text         = content,
+                        text         = parsed.content,
                         isOutgoing   = isSentByMe,
                         timestamp    = msg.createdAt * 1000L,
                         status       = MessageStatus.SENT,
-                        type         = if (parsedType != "text") parsedType else (existing?.type ?: "text"),
-                        mediaId      = parsedMediaId.takeIf { it.isNotBlank() } ?: existing?.mediaId,
-                        senderUserId = msg.effectiveSenderId
+                        type         = if (parsed.type != "text") parsed.type else (existing?.type ?: "text"),
+                        mediaId      = parsed.mediaId.takeIf { it.isNotBlank() } ?: existing?.mediaId,
+                        senderUserId = msg.effectiveSenderId,
+                        groupId      = parsed.groupId ?: existing?.groupId
                     )
                 }
 
                 _messageSenders.update { it + newSenders }
                 _replyContext.update { it + newReplyCtx }
                 chatRepository.saveMessages(uiMessages, conversationId)
+
+                if (sortedMessages.isNotEmpty()) {
+                    val serverIdSet = sortedMessages.map { it.id }.toSet()
+                    val oldestServerTs = sortedMessages.minOf { it.createdAt } * 1000L
+                    existingLocalMessages.forEach { local ->
+                        val sid = local.serverId
+                        if (sid.isNotBlank()
+                            && !sid.startsWith("temp_")
+                            && !sid.startsWith("system_")
+                            && local.timestamp >= oldestServerTs
+                            && sid !in serverIdSet
+                        ) {
+                            chatRepository.deleteMessageByServerId(sid)
+                        }
+                    }
+                }
+
                 mlsManager.flushState()
             }
         } catch (e: Exception) {
@@ -278,10 +328,7 @@ class ChatViewModel(
 
             "message_deleted" -> {
                 val msgId = data.messageId ?: return
-                val existing = _messages.value.find { it.serverId == msgId }
-                if (existing != null) {
-                    chatRepository.saveMessage(existing.copy(text = S.current.messageDeletedEmoji), convId)
-                }
+                chatRepository.deleteMessageByServerId(msgId)
             }
 
             "epoch_changed" -> syncMlsPending(convId)
@@ -355,6 +402,22 @@ class ChatViewModel(
             val localMessages  = chatRepository.getMessagesOnce(conversationId)
             val localServerIds = localMessages.map { it.serverId }.toSet()
 
+            if (serverMessages.isNotEmpty()) {
+                val serverIdSet = serverMessages.map { it.id }.toSet()
+                val oldestServerTs = serverMessages.minOf { it.createdAt } * 1000L
+                localMessages.forEach { local ->
+                    val sid = local.serverId
+                    if (sid.isNotBlank()
+                        && !sid.startsWith("temp_")
+                        && !sid.startsWith("system_")
+                        && local.timestamp >= oldestServerTs
+                        && sid !in serverIdSet
+                    ) {
+                        chatRepository.deleteMessageByServerId(sid)
+                    }
+                }
+            }
+
             val newMessages = serverMessages
                 .filter { it.id !in localServerIds }
                 .sortedBy { it.createdAt }
@@ -407,18 +470,19 @@ class ChatViewModel(
 
             mlsManager.flushState()
 
-            val (parsedType, parsedMediaId, content) = parseMlsPayload(plaintext)
+            val parsed = parseMlsPayload(plaintext)
 
             val msg = Message(
                 id           = msgId.hashCode(),
                 serverId     = msgId,
-                text         = content,
+                text         = parsed.content,
                 isOutgoing   = isOutgoing,
                 timestamp    = createdAt * 1000L,
                 status       = MessageStatus.SENT,
-                type         = if (parsedType != "text") parsedType else "text",
-                mediaId      = parsedMediaId.takeIf { it.isNotBlank() },
-                senderUserId = senderUserId
+                type         = if (parsed.type != "text") parsed.type else "text",
+                mediaId      = parsed.mediaId.takeIf { it.isNotBlank() },
+                senderUserId = senderUserId,
+                groupId      = parsed.groupId
             )
             chatRepository.saveMessage(msg, convId)
         }
@@ -497,8 +561,9 @@ class ChatViewModel(
                 attachments.isEmpty() -> sendTextMessageInternal(convId, text)
                 attachments.size == 1 -> sendPhotoMessageInternal(convId, attachments[0], caption = text)
                 else -> {
-                    sendPhotoMessageInternal(convId, attachments[0], caption = text)
-                    attachments.drop(1).forEach { sendPhotoMessageInternal(convId, it, caption = "") }
+                    val groupId = generateUuid()
+                    sendPhotoMessageInternal(convId, attachments[0], caption = text, groupId = groupId)
+                    attachments.drop(1).forEach { sendPhotoMessageInternal(convId, it, caption = "", groupId = groupId) }
                 }
             }
         }
@@ -543,7 +608,7 @@ class ChatViewModel(
         }
     }
 
-    private suspend fun sendPhotoMessageInternal(convId: String, item: AttachItem, caption: String = "") {
+    private suspend fun sendPhotoMessageInternal(convId: String, item: AttachItem, caption: String = "", groupId: String? = null) {
         val now = Clock.System.now().toEpochMilliseconds()
         val previewBytes = runCatching { item.readUploadBytes() }.getOrNull()
         val replyTo = _replyingTo.value
@@ -553,7 +618,7 @@ class ChatViewModel(
             id = now.hashCode(), text = caption, isOutgoing = true,
             timestamp = now, status = MessageStatus.SENDING,
             type = "image", localPreviewBytes = previewBytes,
-            senderUserId = myUserId
+            senderUserId = myUserId, groupId = groupId
         )
         chatRepository.saveMessage(tempMsg, convId)
 
@@ -578,7 +643,8 @@ class ChatViewModel(
             api.uploadEncryptedBytesToUrl(initResp.uploadUrl, encrypted.encryptedBytes, mime)
             api.confirmMediaUpload(initResp.mediaId)
 
-            val mlsPayload    = "[image:${initResp.mediaId}]$caption"
+            val mlsPayload    = if (groupId != null) "[image:${initResp.mediaId}:$groupId]$caption"
+                                else "[image:${initResp.mediaId}]$caption"
             val ciphertextB64 = mlsManager.encrypt(convId, mlsPayload)
             mlsManager.flushState()
 
@@ -819,36 +885,42 @@ class ChatViewModel(
         viewModelScope.launch {
             try {
                 api.deleteMessage(message.serverId, deleteForEveryone = true)
-                chatRepository.saveMessage(
-                    message.copy(text = S.current.messageDeleted, type = "text", mediaId = null),
-                    convId
-                )
+                chatRepository.deleteMessageByServerId(message.serverId)
             } catch (e: Exception) {
                 _error.value = S.current.deleteError(e.message ?: "")
             }
         }
     }
 
-    private fun parseMlsPayload(payload: String): Triple<String, String, String> {
+    private data class ParsedMlsPayload(
+        val type: String,
+        val mediaId: String,
+        val content: String,
+        val groupId: String? = null
+    )
+
+    private fun parseMlsPayload(payload: String): ParsedMlsPayload {
         if (payload.startsWith("[image:")) {
             val closeIdx = payload.indexOf(']')
-            if (closeIdx == -1) return Triple("text", "", payload)
-            val mediaId = payload.substring(7, closeIdx)
+            if (closeIdx == -1) return ParsedMlsPayload("text", "", payload)
+            val metaInfo = payload.substring(7, closeIdx).split(":")
+            val mediaId = metaInfo[0]
+            val groupId = if (metaInfo.size > 1) metaInfo[1] else null
             val caption = payload.substring(closeIdx + 1).trim()
-            return Triple("image", mediaId, caption)
+            return ParsedMlsPayload("image", mediaId, caption, groupId)
         }
         if (payload.startsWith("[voice:")) {
             val closeIdx = payload.indexOf(']')
-            if (closeIdx == -1) return Triple("text", "", payload)
+            if (closeIdx == -1) return ParsedMlsPayload("text", "", payload)
 
             val metaInfo = payload.substring(7, closeIdx).split(":")
             val mediaId = metaInfo[0]
             val waveform = if (metaInfo.size > 1) metaInfo[1] else ""
             val durationMs = payload.substring(closeIdx + 1).trim()
 
-            return Triple("voice", mediaId, "$durationMs|$waveform")
+            return ParsedMlsPayload("voice", mediaId, "$durationMs|$waveform")
         }
-        return Triple("text", "", payload)
+        return ParsedMlsPayload("text", "", payload)
     }
 
     override fun onCleared() {
@@ -861,4 +933,18 @@ class ChatViewModel(
         typingJob?.cancel()
         dbObserveJob?.cancel()
     }
+}
+
+/**
+ * In-memory cache for per-chat scroll positions.
+ * Survives navigation between screens but NOT app restart.
+ */
+object ChatScrollCache {
+    private val positions = mutableMapOf<String, Pair<Int, Int>>()
+
+    fun save(conversationId: String, index: Int, offset: Int) {
+        positions[conversationId] = index to offset
+    }
+
+    fun restore(conversationId: String): Pair<Int, Int>? = positions[conversationId]
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatsScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ChatsScreen.kt
@@ -45,6 +45,9 @@ import com.example.memegram.audio.VoicePlaybackBar
 import com.example.memegram.localization.LocalStrings
 import kotlin.time.Clock
 import kotlin.time.Instant
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
+import com.example.memegram.utils.ImageTopAppBarBox
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -109,7 +112,7 @@ fun ChatsScreen(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(160.dp)
+                        .aspectRatio(2.5f)
                         .clickable { scope.launch { drawerState.close(); onProfileClick() } }
                 ) {
                     if (profileCover != null) {
@@ -120,14 +123,14 @@ fun ChatsScreen(
                         Box(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surfaceVariant))
                     }
                     Column(
-                        modifier = Modifier.align(Alignment.BottomStart).padding(16.dp)
+                        modifier = Modifier.align(Alignment.BottomStart).padding(start = 16.sdp, bottom = 8.sdp)
                     ) {
                         Box(
                             modifier = Modifier
-                                .size(64.dp)
+                                .size(52.sdp)
                                 .clip(CircleShape)
                                 .background(topBarColor)
-                                .border(2.dp, Color.White, CircleShape),
+                                .border(2.sdp, Color.White, CircleShape),
                             contentAlignment = Alignment.Center
                         ) {
                             if (profileAvatar != null) {
@@ -140,73 +143,76 @@ fun ChatsScreen(
                                     color = Color.White, fontWeight = FontWeight.Bold)
                             }
                         }
-                        Spacer(Modifier.height(8.dp))
+                        Spacer(Modifier.height(4.sdp))
                         Text(
                             text = profileUsername,
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Bold,
-                            color = if (profileCover != null) Color.White else MaterialTheme.colorScheme.onSurface
+                            color = if (profileCover != null) Color.White else MaterialTheme.colorScheme.onSurface,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
                         )
                     }
                 }
 
                 HorizontalDivider()
-                Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(8.sdp))
 
                 NavigationDrawerItem(
                     label = { Text(s.settingsAppearance) },
                     icon = { Icon(Icons.Default.Palette, null) },
                     selected = false,
                     onClick = { scope.launch { drawerState.close(); onAppearanceClick() } },
-                    modifier = Modifier.padding(horizontal = 12.dp)
+                    modifier = Modifier.padding(horizontal = 12.sdp)
                 )
                 NavigationDrawerItem(
                     label = { Text(s.settingsNotifications) },
                     icon = { Icon(Icons.Default.Notifications, null) },
                     selected = false,
                     onClick = { scope.launch { drawerState.close(); onNotificationsClick() } },
-                    modifier = Modifier.padding(horizontal = 12.dp)
+                    modifier = Modifier.padding(horizontal = 12.sdp)
                 )
                 NavigationDrawerItem(
                     label = { Text(s.settingsPrivacy) },
                     icon = { Icon(Icons.Default.Lock, null) },
                     selected = false,
                     onClick = { scope.launch { drawerState.close(); onPrivacyClick() } },
-                    modifier = Modifier.padding(horizontal = 12.dp)
+                    modifier = Modifier.padding(horizontal = 12.sdp)
                 )
                 NavigationDrawerItem(
                     label = { Text(s.settingsDataAndStorage) },
                     icon = { Icon(Icons.Default.Storage, null) },
                     selected = false,
                     onClick = { scope.launch { drawerState.close(); onStorageClick() } },
-                    modifier = Modifier.padding(horizontal = 12.dp)
+                    modifier = Modifier.padding(horizontal = 12.sdp)
                 )
                 NavigationDrawerItem(
                     label = { Text(s.settingsContacts) },
                     icon = { Icon(Icons.Default.People, null) },
                     selected = false,
                     onClick = { scope.launch { drawerState.close() }; onContactsClick() },
-                    modifier = Modifier.padding(horizontal = 12.dp)
+                    modifier = Modifier.padding(horizontal = 12.sdp)
                 )
                 NavigationDrawerItem(
                     label   = { Text(s.settingsLinkedDevices) },
                     icon    = { Icon(Icons.Default.Devices, null) },
                     selected = false,
                     onClick = { scope.launch { drawerState.close() }; onLinkedDevicesClick() },
-                    modifier = Modifier.padding(horizontal = 12.dp)
+                    modifier = Modifier.padding(horizontal = 12.sdp)
                 )
                 NavigationDrawerItem(
                     label = { Text(s.settingsLanguage) },
                     icon = { Icon(Icons.Default.Language, null) },
                     selected = false,
                     onClick = { scope.launch { drawerState.close(); onLanguageClick() } },
-                    modifier = Modifier.padding(horizontal = 12.dp)
+                    modifier = Modifier.padding(horizontal = 12.sdp)
                 )
             }
         }
     ) {
         Scaffold(
             topBar = {
+                ImageTopAppBarBox(topBarColor) { bgColor ->
                 TopAppBar(
                     navigationIcon = {
                         if (isSearchMode) {
@@ -229,14 +235,14 @@ fun ChatsScreen(
                                     value = searchQuery,
                                     onValueChange = { viewModel.setSearchQuery(it) },
                                     singleLine = true,
-                                    textStyle = TextStyle(color = topBarTextColor, fontSize = 16.sp),
+                                    textStyle = TextStyle(color = topBarTextColor, fontSize = 16.ssp),
                                     cursorBrush = SolidColor(topBarTextColor),
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .focusRequester(focusRequester),
                                     decorationBox = { inner ->
                                         if (searchQuery.isEmpty()) {
-                                            Text(s.searchPlaceholder, color = topBarTextColor.copy(alpha = 0.6f), fontSize = 16.sp)
+                                            Text(s.searchPlaceholder, color = topBarTextColor.copy(alpha = 0.6f), fontSize = 16.ssp)
                                         }
                                         inner()
                                     }
@@ -254,16 +260,16 @@ fun ChatsScreen(
                             Box {
                                 Surface(
                                     onClick = { showAddMenu = true },
-                                    shape = RoundedCornerShape(20.dp),
+                                    shape = RoundedCornerShape(20.sdp),
                                     color = topBarTextColor.copy(alpha = 0.15f),
-                                    modifier = Modifier.padding(end = 8.dp)
+                                    modifier = Modifier.padding(end = 8.sdp)
                                 ) {
                                     Text(
                                         text = "Add",
                                         color = topBarTextColor,
                                         fontWeight = FontWeight.SemiBold,
-                                        fontSize = 14.sp,
-                                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 6.dp)
+                                        fontSize = 14.ssp,
+                                        modifier = Modifier.padding(horizontal = 14.sdp, vertical = 6.sdp)
                                     )
                                 }
                                 DropdownMenu(
@@ -301,10 +307,11 @@ fun ChatsScreen(
                         }
                     },
                     colors = TopAppBarDefaults.topAppBarColors(
-                        containerColor = topBarColor,
+                        containerColor = bgColor,
                         titleContentColor = topBarTextColor
                     )
                 )
+                }
                 if (showAddKeyDialog) {
                     AlertDialog(
                         onDismissRequest = { showAddKeyDialog = false },
@@ -312,7 +319,7 @@ fun ChatsScreen(
                         text = {
                             Column {
                                 Text(s.enterPublicKeyToChat, style = MaterialTheme.typography.bodySmall)
-                                Spacer(Modifier.height(8.dp))
+                                Spacer(Modifier.height(8.sdp))
                                 OutlinedTextField(
                                     value = newKeyInput,
                                     onValueChange = { newKeyInput = it },
@@ -371,7 +378,7 @@ fun ChatsScreen(
                             items(chats, key = { it.id }) { chat ->
                                 ChatItem(chat = chat, onClick = { onChatClick(chat) })
                                 HorizontalDivider(
-                                    modifier = Modifier.padding(start = 76.dp),
+                                    modifier = Modifier.padding(start = 76.sdp),
                                     color = MaterialTheme.colorScheme.surfaceVariant
                                 )
                             }
@@ -404,17 +411,17 @@ fun ChatItem(chat: ChatModel, onClick: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = 16.sdp, vertical = 12.sdp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         AvatarImage(
             mediaId = chat.avatarMediaId,
-            size = 50.dp,
+            size = 50.sdp,
             fallbackLetter = chat.name.take(1).uppercase(),
             backgroundColor = Color(0xFF6075F2)
         )
 
-        Spacer(modifier = Modifier.width(16.dp))
+        Spacer(modifier = Modifier.width(16.sdp))
 
         Column(modifier = Modifier.weight(1f)) {
             Text(
@@ -424,18 +431,18 @@ fun ChatItem(chat: ChatModel, onClick: () -> Unit) {
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(4.sdp))
 
             Row(verticalAlignment = Alignment.CenterVertically) {
                 if (!chat.isLastMessageMine && !chat.lastSenderName.isNullOrBlank()) {
                     AvatarImage(
                         mediaId = chat.lastSenderAvatarMediaId,
-                        size = 18.dp,
+                        size = 18.sdp,
                         fallbackLetter = chat.lastSenderName.take(1).uppercase(),
                         backgroundColor = MaterialTheme.colorScheme.primaryContainer,
                         textColor = MaterialTheme.colorScheme.onPrimaryContainer
                     )
-                    Spacer(modifier = Modifier.width(6.dp))
+                    Spacer(modifier = Modifier.width(6.sdp))
                 } else if (chat.isLastMessageMine) {
                     Text(
                         text = s.youPrefix,
@@ -457,18 +464,18 @@ fun ChatItem(chat: ChatModel, onClick: () -> Unit) {
 
         Column(
             horizontalAlignment = Alignment.End,
-            modifier = Modifier.padding(start = 8.dp)
+            modifier = Modifier.padding(start = 8.sdp)
         ) {
             Text(
                 text = formatChatTime(chat.timestamp),
                 style = MaterialTheme.typography.bodySmall,
                 color = if (chat.unreadCount > 0) MaterialTheme.colorScheme.primary else Color.Gray
             )
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(4.sdp))
             if (chat.unreadCount > 0) {
                 Box(
                     modifier = Modifier
-                        .size(24.dp)
+                        .size(24.sdp)
                         .clip(CircleShape)
                         .background(MaterialTheme.colorScheme.primary),
                     contentAlignment = Alignment.Center

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ContactsScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ContactsScreen.kt
@@ -22,6 +22,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.memegram.data.models.ContactEntry
 import com.example.memegram.localization.LocalStrings
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
+import com.example.memegram.utils.ImageTopAppBarBox
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -88,16 +91,16 @@ fun ContactsScreen(
                 Column {
                     Text(
                         s.enterPublicKey,
-                        fontSize = 13.sp,
+                        fontSize = 13.ssp,
                         color = Color.Gray,
-                        modifier = Modifier.padding(bottom = 12.dp)
+                        modifier = Modifier.padding(bottom = 12.sdp)
                     )
                     OutlinedTextField(
                         value = publicKeyInput,
                         onValueChange = { publicKeyInput = it },
                         label = { Text(s.publicKey) },
                         singleLine = true,
-                        shape = RoundedCornerShape(12.dp),
+                        shape = RoundedCornerShape(12.sdp),
                         modifier = Modifier.fillMaxWidth(),
                         enabled = !isAdding,
                         colors = OutlinedTextFieldDefaults.colors(
@@ -115,8 +118,8 @@ fun ContactsScreen(
                 ) {
                     if (isAdding) {
                         CircularProgressIndicator(
-                            modifier = Modifier.size(16.dp),
-                            strokeWidth = 2.dp,
+                            modifier = Modifier.size(16.sdp),
+                            strokeWidth = 2.sdp,
                             color = Color.White
                         )
                     } else {
@@ -177,6 +180,7 @@ fun ContactsScreen(
 
     Scaffold(
         topBar = {
+            ImageTopAppBarBox(topBarColor) { bgColor ->
             TopAppBar(
                 title = { Text(s.contactsTitle) },
                 navigationIcon = {
@@ -190,12 +194,13 @@ fun ContactsScreen(
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = topBarColor,
+                    containerColor = bgColor,
                     titleContentColor = topBarTextColor,
                     actionIconContentColor = topBarTextColor,
                     navigationIconContentColor = topBarTextColor
                 )
             )
+            }
         }
     ) { paddingValues ->
         Box(
@@ -216,22 +221,22 @@ fun ContactsScreen(
                         Icon(
                             Icons.Default.People,
                             contentDescription = null,
-                            modifier = Modifier.size(64.dp),
+                            modifier = Modifier.size(64.sdp),
                             tint = Color.LightGray
                         )
-                        Spacer(Modifier.height(12.dp))
+                        Spacer(Modifier.height(12.sdp))
                         Text(
                             s.noContacts,
                             style = MaterialTheme.typography.titleMedium,
                             color = Color.Gray
                         )
-                        Spacer(Modifier.height(4.dp))
+                        Spacer(Modifier.height(4.sdp))
                         Text(
                             s.addContactHint,
-                            fontSize = 13.sp,
+                            fontSize = 13.ssp,
                             color = Color.Gray,
                             textAlign = TextAlign.Center,
-                            modifier = Modifier.padding(horizontal = 32.dp)
+                            modifier = Modifier.padding(horizontal = 32.sdp)
                         )
                     }
                 }
@@ -257,7 +262,7 @@ fun ContactsScreen(
                                     onBlock = { pendingBlockId = entry.contactUserId }
                                 )
                                 HorizontalDivider(
-                                    modifier = Modifier.padding(start = 72.dp),
+                                    modifier = Modifier.padding(start = 72.sdp),
                                     color = MaterialTheme.colorScheme.surfaceVariant
                                 )
                             }
@@ -279,7 +284,7 @@ fun ContactsScreen(
                                     onBlock = { pendingBlockId = entry.contactUserId }
                                 )
                                 HorizontalDivider(
-                                    modifier = Modifier.padding(start = 72.dp),
+                                    modifier = Modifier.padding(start = 72.sdp),
                                     color = MaterialTheme.colorScheme.surfaceVariant
                                 )
                             }
@@ -295,10 +300,10 @@ fun ContactsScreen(
 private fun SectionHeader(title: String, accentColor: Color) {
     Text(
         text = title,
-        fontSize = 12.sp,
+        fontSize = 12.ssp,
         fontWeight = FontWeight.Bold,
         color = accentColor,
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        modifier = Modifier.padding(horizontal = 16.sdp, vertical = 8.sdp)
     )
 }
 
@@ -320,30 +325,30 @@ private fun ContactItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            .padding(horizontal = 16.sdp, vertical = 10.sdp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         AvatarImage(
             mediaId = entry.profile?.avatarMediaId,
-            size = 46.dp,
+            size = 46.sdp,
             fallbackLetter = displayName.take(1).uppercase(),
             backgroundColor = if (entry.isFavorite) accentColor.copy(alpha = 0.2f)
                 else MaterialTheme.colorScheme.surfaceVariant,
             textColor = if (entry.isFavorite) accentColor else Color.Gray
         )
 
-        Spacer(Modifier.width(14.dp))
+        Spacer(Modifier.width(14.sdp))
 
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = displayName,
                 fontWeight = FontWeight.Medium,
-                fontSize = 15.sp
+                fontSize = 15.ssp
             )
             entry.profile?.bio?.takeIf { it.isNotBlank() }?.let { bio ->
                 Text(
                     text = bio,
-                    fontSize = 12.sp,
+                    fontSize = 12.ssp,
                     color = Color.Gray,
                     maxLines = 1
                 )

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/CreateGroupScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/CreateGroupScreen.kt
@@ -17,12 +17,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.example.memegram.localization.LocalStrings
 import org.koin.compose.viewmodel.koinViewModel
+import com.example.memegram.utils.sdp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateGroupScreen(
     onBack: () -> Unit,
-    onGroupCreated: (String) -> Unit,
+    onGroupCreated: (String, String) -> Unit,
     vm: ContactsViewModel = koinViewModel()
 ) {
     val contacts by vm.contacts.collectAsState()
@@ -37,7 +38,7 @@ fun CreateGroupScreen(
     LaunchedEffect(createdChatId) {
         createdChatId?.let {
             vm.clearChatCreated()
-            onGroupCreated(it)
+            onGroupCreated(it, groupName)
         }
     }
 
@@ -70,7 +71,7 @@ fun CreateGroupScreen(
                 Text(
                     text = error!!,
                     color = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.padding(16.dp)
+                    modifier = Modifier.padding(16.sdp)
                 )
             }
 
@@ -80,7 +81,7 @@ fun CreateGroupScreen(
                 label = { Text(s.groupName) },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                    .padding(horizontal = 16.sdp, vertical = 8.sdp),
                 singleLine = true,
                 enabled = !isCreating
             )
@@ -89,7 +90,7 @@ fun CreateGroupScreen(
                 text = s.membersSelected(selectedUserIds.size),
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp)
+                modifier = Modifier.padding(start = 16.sdp, top = 16.sdp, bottom = 8.sdp)
             )
 
             if (isCreating) {
@@ -114,10 +115,10 @@ fun CreateGroupScreen(
                             headlineContent = { Text(name) },
                             leadingContent = {
                                 Surface(
-                                    modifier = Modifier.size(40.dp).clip(CircleShape),
+                                    modifier = Modifier.size(40.sdp).clip(CircleShape),
                                     color = MaterialTheme.colorScheme.secondaryContainer
                                 ) {
-                                    Icon(Icons.Default.Person, contentDescription = null, modifier = Modifier.padding(8.dp))
+                                    Icon(Icons.Default.Person, contentDescription = null, modifier = Modifier.padding(8.sdp))
                                 }
                             },
                             trailingContent = {

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/DateScrubber.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/DateScrubber.kt
@@ -27,6 +27,8 @@ import kotlinx.datetime.number
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
 import kotlin.time.Instant
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
 
 @Composable
 fun DateScrubber(
@@ -43,18 +45,18 @@ fun DateScrubber(
     var dragFraction by remember { mutableStateOf(0f) }
     var dragLabel    by remember { mutableStateOf("") }
 
-    BoxWithConstraints(modifier = modifier.width(40.dp)) {
+    BoxWithConstraints(modifier = modifier.width(40.sdp)) {
         val trackH = maxHeight
 
         Box(
             modifier = Modifier
                 .align(Alignment.CenterEnd)
                 .fillMaxHeight()
-                .width(3.dp)
+                .width(3.sdp)
                 .background(
                     if (isDragging) MaterialTheme.colorScheme.primary.copy(alpha = 0.85f)
                     else Color.Gray.copy(alpha = 0.3f),
-                    RoundedCornerShape(2.dp)
+                    RoundedCornerShape(2.sdp)
                 )
         )
 
@@ -62,8 +64,8 @@ fun DateScrubber(
             Box(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .offset(x = 0.dp, y = trackH * dragFraction - 6.dp)
-                    .size(12.dp)
+                    .offset(x = 0.sdp, y = trackH * dragFraction - 6.sdp)
+                    .size(12.sdp)
                     .background(MaterialTheme.colorScheme.primary, CircleShape)
             )
         }
@@ -72,16 +74,16 @@ fun DateScrubber(
             Text(
                 text     = dragLabel,
                 color    = Color.White,
-                fontSize = 12.sp,
+                fontSize = 12.ssp,
                 maxLines = 1,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .offset(
-                        x = (-46).dp,
-                        y = (trackH * dragFraction - 12.dp).coerceAtLeast(0.dp)
+                        x = (-46).sdp,
+                        y = (trackH * dragFraction - 12.sdp).coerceAtLeast(0.sdp)
                     )
-                    .background(Color.Black.copy(alpha = 0.78f), RoundedCornerShape(6.dp))
-                    .padding(horizontal = 8.dp, vertical = 4.dp)
+                    .background(Color.Black.copy(alpha = 0.78f), RoundedCornerShape(6.sdp))
+                    .padding(horizontal = 8.sdp, vertical = 4.sdp)
             )
         }
 

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/GroupProfileScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/GroupProfileScreen.kt
@@ -20,10 +20,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.example.memegram.localization.AppStrings
 import com.example.memegram.localization.LocalStrings
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
+import com.example.memegram.utils.ImageTopAppBarBox
 
 private fun roleDisplayName(role: String, s: AppStrings): String = when (role) {
     "owner" -> s.roleOwner
@@ -224,7 +225,7 @@ fun GroupProfileScreen(
                                 leadingContent = {
                                     AvatarImage(
                                         mediaId = contact.profile?.avatarMediaId,
-                                        size = 36.dp,
+                                        size = 36.sdp,
                                         fallbackLetter = name.take(1).uppercase(),
                                         backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
                                         textColor = MaterialTheme.colorScheme.onSecondaryContainer
@@ -258,6 +259,7 @@ fun GroupProfileScreen(
 
     Scaffold(
         topBar = {
+            ImageTopAppBarBox(topBarColor) { bgColor ->
             TopAppBar(
                 title = { Text(s.groupInfo, color = topBarTextColor) },
                 navigationIcon = {
@@ -265,8 +267,9 @@ fun GroupProfileScreen(
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = topBarTextColor)
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = topBarColor)
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = bgColor)
             )
+            }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { paddingValues ->
@@ -274,16 +277,16 @@ fun GroupProfileScreen(
             modifier = Modifier.fillMaxSize().padding(paddingValues)
         ) {
             Column(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
+                modifier = Modifier.fillMaxWidth().padding(vertical = 24.sdp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Box(
-                    modifier = Modifier.size(100.dp).clip(CircleShape).background(MaterialTheme.colorScheme.primary),
+                    modifier = Modifier.size(100.sdp).clip(CircleShape).background(MaterialTheme.colorScheme.primary),
                     contentAlignment = Alignment.Center
                 ) {
-                    Text(groupName.take(1).uppercase(), color = Color.White, fontSize = 48.sp, fontWeight = FontWeight.Bold)
+                    Text(groupName.take(1).uppercase(), color = Color.White, fontSize = 48.ssp, fontWeight = FontWeight.Bold)
                 }
-                Spacer(Modifier.height(16.dp))
+                Spacer(Modifier.height(16.sdp))
                 Text(groupName, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
                 Text(s.membersCount(members.size), color = Color.Gray, style = MaterialTheme.typography.bodyMedium)
             }
@@ -302,20 +305,20 @@ fun GroupProfileScreen(
                 modifier = Modifier.clickable { showLeaveConfirm = true }
             )
 
-            HorizontalDivider(thickness = 8.dp, color = MaterialTheme.colorScheme.surfaceVariant)
+            HorizontalDivider(thickness = 8.sdp, color = MaterialTheme.colorScheme.surfaceVariant)
 
             OutlinedTextField(
                 value = searchQuery,
                 onValueChange = { viewModel.updateSearchQuery(it) },
                 placeholder = { Text(s.searchMembers) },
                 leadingIcon = { Icon(Icons.Default.Search, null) },
-                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                modifier = Modifier.fillMaxWidth().padding(16.sdp),
                 singleLine = true,
                 shape = CircleShape
             )
 
             if (isLoading && members.isEmpty()) {
-                Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                Box(Modifier.fillMaxWidth().padding(16.sdp), contentAlignment = Alignment.Center) {
                     CircularProgressIndicator()
                 }
             } else {
@@ -328,7 +331,7 @@ fun GroupProfileScreen(
                             leadingContent = {
                                 AvatarImage(
                                     mediaId = member.user.avatarMediaId,
-                                    size = 40.dp,
+                                    size = 40.sdp,
                                     fallbackLetter = (member.user.username ?: "?").take(1).uppercase(),
                                     backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
                                     textColor = MaterialTheme.colorScheme.onSecondaryContainer

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ImageCropScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ImageCropScreen.kt
@@ -1,0 +1,349 @@
+package com.example.memegram
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.memegram.localization.LocalStrings
+import kotlin.math.roundToInt
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
+
+private enum class DragMode {
+    NONE, MOVE, RESIZE_TL, RESIZE_TR, RESIZE_BL, RESIZE_BR
+}
+
+@Composable
+fun ImageCropScreen(
+    imageBytes: ByteArray,
+    aspectRatio: Float = 0f,
+    onCropped: (ByteArray) -> Unit,
+    onCancel: () -> Unit
+) {
+    val s = LocalStrings.current
+    val imageBitmap = remember(imageBytes) {
+        runCatching { imageBytes.decodeToImageBitmap() }.getOrNull()
+    }
+
+    if (imageBitmap == null) {
+        onCancel()
+        return
+    }
+
+    val imgW = imageBitmap.width.toFloat()
+    val imgH = imageBitmap.height.toFloat()
+
+    var canvasSize by remember { mutableStateOf(Size.Zero) }
+
+    val imageRect by remember(canvasSize, imgW, imgH) {
+        derivedStateOf {
+            if (canvasSize == Size.Zero) Rect.Zero
+            else {
+                val scaleX = canvasSize.width / imgW
+                val scaleY = canvasSize.height / imgH
+                val scale = minOf(scaleX, scaleY)
+                val dstW = imgW * scale
+                val dstH = imgH * scale
+                val offsetX = (canvasSize.width - dstW) / 2f
+                val offsetY = (canvasSize.height - dstH) / 2f
+                Rect(offsetX, offsetY, offsetX + dstW, offsetY + dstH)
+            }
+        }
+    }
+
+    val drawnRect by remember(canvasSize, imgW, imgH) {
+        derivedStateOf {
+            if (imageRect == Rect.Zero) Rect.Zero
+            else {
+                val l = imageRect.left.roundToInt()
+                val t = imageRect.top.roundToInt()
+                val w = imageRect.width.roundToInt()
+                val h = imageRect.height.roundToInt()
+                Rect(l.toFloat(), t.toFloat(), (l + w).toFloat(), (t + h).toFloat())
+            }
+        }
+    }
+
+    var cropRect by remember { mutableStateOf(Rect.Zero) }
+    var initialized by remember { mutableStateOf(false) }
+
+    LaunchedEffect(drawnRect) {
+        if (drawnRect != Rect.Zero && !initialized) {
+            val iRect = drawnRect
+            if (aspectRatio > 0f) {
+                val fw: Float
+                val fh: Float
+                if (iRect.width / iRect.height > aspectRatio) {
+                    fh = iRect.height * 0.75f
+                    fw = fh * aspectRatio
+                } else {
+                    fw = iRect.width * 0.75f
+                    fh = fw / aspectRatio
+                }
+                val cx = iRect.left + (iRect.width - fw) / 2f
+                val cy = iRect.top + (iRect.height - fh) / 2f
+                cropRect = Rect(cx, cy, cx + fw, cy + fh)
+            } else {
+                val size = minOf(iRect.width, iRect.height) * 0.75f
+                val cx = iRect.left + (iRect.width - size) / 2f
+                val cy = iRect.top + (iRect.height - size) / 2f
+                cropRect = Rect(cx, cy, cx + size, cy + size)
+            }
+            initialized = true
+        }
+    }
+
+    var dragMode by remember { mutableStateOf(DragMode.NONE) }
+    val handleSize = 40f
+
+    fun detectDragMode(pos: Offset): DragMode {
+        val r = cropRect
+        val hs = handleSize
+        return when {
+            Rect(r.left - hs, r.top - hs, r.left + hs, r.top + hs).contains(pos) -> DragMode.RESIZE_TL
+            Rect(r.right - hs, r.top - hs, r.right + hs, r.top + hs).contains(pos) -> DragMode.RESIZE_TR
+            Rect(r.left - hs, r.bottom - hs, r.left + hs, r.bottom + hs).contains(pos) -> DragMode.RESIZE_BL
+            Rect(r.right - hs, r.bottom - hs, r.right + hs, r.bottom + hs).contains(pos) -> DragMode.RESIZE_BR
+            r.contains(pos) -> DragMode.MOVE
+            else -> DragMode.NONE
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFF1B1B1F))
+            .statusBarsPadding()
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(16.sdp)
+        ) {
+            Canvas(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .pointerInput(drawnRect) {
+                        detectDragGestures(
+                            onDragStart = { offset ->
+                                dragMode = detectDragMode(offset)
+                            },
+                            onDrag = { change, dragAmount ->
+                                change.consume()
+                                val iRect = drawnRect
+                                val minSize = 60f
+
+                                when (dragMode) {
+                                    DragMode.MOVE -> {
+                                        val newLeft = (cropRect.left + dragAmount.x)
+                                            .coerceIn(iRect.left, iRect.right - cropRect.width)
+                                        val newTop = (cropRect.top + dragAmount.y)
+                                            .coerceIn(iRect.top, iRect.bottom - cropRect.height)
+                                        cropRect = Rect(
+                                            newLeft, newTop,
+                                            newLeft + cropRect.width,
+                                            newTop + cropRect.height
+                                        )
+                                    }
+                                    DragMode.RESIZE_TL -> {
+                                        var newLeft = (cropRect.left + dragAmount.x).coerceIn(iRect.left, cropRect.right - minSize)
+                                        var newTop = (cropRect.top + dragAmount.y).coerceIn(iRect.top, cropRect.bottom - minSize)
+                                        if (aspectRatio > 0f) {
+                                            val w = cropRect.right - newLeft
+                                            val h = w / aspectRatio
+                                            newTop = cropRect.bottom - h
+                                            if (newTop < iRect.top) {
+                                                newTop = iRect.top
+                                                val h2 = cropRect.bottom - newTop
+                                                newLeft = cropRect.right - h2 * aspectRatio
+                                            }
+                                        }
+                                        cropRect = Rect(newLeft, newTop, cropRect.right, cropRect.bottom)
+                                    }
+                                    DragMode.RESIZE_TR -> {
+                                        var newRight = (cropRect.right + dragAmount.x).coerceIn(cropRect.left + minSize, iRect.right)
+                                        var newTop = (cropRect.top + dragAmount.y).coerceIn(iRect.top, cropRect.bottom - minSize)
+                                        if (aspectRatio > 0f) {
+                                            val w = newRight - cropRect.left
+                                            val h = w / aspectRatio
+                                            newTop = cropRect.bottom - h
+                                            if (newTop < iRect.top) {
+                                                newTop = iRect.top
+                                                val h2 = cropRect.bottom - newTop
+                                                newRight = cropRect.left + h2 * aspectRatio
+                                            }
+                                        }
+                                        cropRect = Rect(cropRect.left, newTop, newRight, cropRect.bottom)
+                                    }
+                                    DragMode.RESIZE_BL -> {
+                                        var newLeft = (cropRect.left + dragAmount.x).coerceIn(iRect.left, cropRect.right - minSize)
+                                        var newBottom = (cropRect.bottom + dragAmount.y).coerceIn(cropRect.top + minSize, iRect.bottom)
+                                        if (aspectRatio > 0f) {
+                                            val w = cropRect.right - newLeft
+                                            newBottom = cropRect.top + w / aspectRatio
+                                            if (newBottom > iRect.bottom) {
+                                                newBottom = iRect.bottom
+                                                val h2 = newBottom - cropRect.top
+                                                newLeft = cropRect.right - h2 * aspectRatio
+                                            }
+                                        }
+                                        cropRect = Rect(newLeft, cropRect.top, cropRect.right, newBottom)
+                                    }
+                                    DragMode.RESIZE_BR -> {
+                                        var newRight = (cropRect.right + dragAmount.x).coerceIn(cropRect.left + minSize, iRect.right)
+                                        var newBottom = (cropRect.bottom + dragAmount.y).coerceIn(cropRect.top + minSize, iRect.bottom)
+                                        if (aspectRatio > 0f) {
+                                            val w = newRight - cropRect.left
+                                            newBottom = cropRect.top + w / aspectRatio
+                                            if (newBottom > iRect.bottom) {
+                                                newBottom = iRect.bottom
+                                                val h2 = newBottom - cropRect.top
+                                                newRight = cropRect.left + h2 * aspectRatio
+                                            }
+                                        }
+                                        cropRect = Rect(cropRect.left, cropRect.top, newRight, newBottom)
+                                    }
+                                    DragMode.NONE -> {}
+                                }
+                            },
+                            onDragEnd = { dragMode = DragMode.NONE }
+                        )
+                    }
+            ) {
+                canvasSize = size
+
+                if (drawnRect == Rect.Zero) return@Canvas
+
+                val dstLeft = drawnRect.left.roundToInt()
+                val dstTop = drawnRect.top.roundToInt()
+                val dstW = drawnRect.width.roundToInt()
+                val dstH = drawnRect.height.roundToInt()
+
+                drawImage(
+                    image = imageBitmap,
+                    srcOffset = IntOffset.Zero,
+                    srcSize = IntSize(imageBitmap.width, imageBitmap.height),
+                    dstOffset = IntOffset(dstLeft, dstTop),
+                    dstSize = IntSize(dstW, dstH)
+                )
+
+                val overlayColor = Color.Black.copy(alpha = 0.55f)
+                // Top
+                drawRect(overlayColor, Offset(drawnRect.left, drawnRect.top),
+                    Size(drawnRect.width, (cropRect.top - drawnRect.top).coerceAtLeast(0f)))
+                // Bottom
+                drawRect(overlayColor, Offset(drawnRect.left, cropRect.bottom),
+                    Size(drawnRect.width, (drawnRect.bottom - cropRect.bottom).coerceAtLeast(0f)))
+                // Left
+                drawRect(overlayColor, Offset(drawnRect.left, cropRect.top),
+                    Size((cropRect.left - drawnRect.left).coerceAtLeast(0f), cropRect.height))
+                // Right
+                drawRect(overlayColor, Offset(cropRect.right, cropRect.top),
+                    Size((drawnRect.right - cropRect.right).coerceAtLeast(0f), cropRect.height))
+
+                // Crop frame border
+                drawRect(
+                    color = Color.White,
+                    topLeft = Offset(cropRect.left, cropRect.top),
+                    size = Size(cropRect.width, cropRect.height),
+                    style = Stroke(width = 2f)
+                )
+
+                // Grid lines
+                val thirdW = cropRect.width / 3f
+                val thirdH = cropRect.height / 3f
+                val gridColor = Color.White.copy(alpha = 0.4f)
+                for (i in 1..2) {
+                    // Vertical
+                    drawLine(gridColor,
+                        Offset(cropRect.left + thirdW * i, cropRect.top),
+                        Offset(cropRect.left + thirdW * i, cropRect.bottom),
+                        strokeWidth = 1f)
+                    // Horizontal
+                    drawLine(gridColor,
+                        Offset(cropRect.left, cropRect.top + thirdH * i),
+                        Offset(cropRect.right, cropRect.top + thirdH * i),
+                        strokeWidth = 1f)
+                }
+
+                // Corner handles
+                val cornerLen = 24f
+                val cornerWidth = 4f
+                val white = Color.White
+                listOf(
+                    Offset(cropRect.left, cropRect.top),
+                    Offset(cropRect.right, cropRect.top),
+                    Offset(cropRect.left, cropRect.bottom),
+                    Offset(cropRect.right, cropRect.bottom)
+                ).forEachIndexed { idx, corner ->
+                    val dx = if (idx % 2 == 0) 1f else -1f
+                    val dy = if (idx < 2) 1f else -1f
+                    drawLine(white, corner, Offset(corner.x + cornerLen * dx, corner.y), strokeWidth = cornerWidth)
+                    drawLine(white, corner, Offset(corner.x, corner.y + cornerLen * dy), strokeWidth = cornerWidth)
+                }
+            }
+        }
+
+        // Bottom buttons
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.sdp, vertical = 16.sdp)
+                .navigationBarsPadding(),
+            horizontalArrangement = Arrangement.spacedBy(16.sdp)
+        ) {
+            OutlinedButton(
+                onClick = onCancel,
+                modifier = Modifier.weight(1f).height(50.sdp),
+                shape = RoundedCornerShape(12.sdp),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = Color.White
+                )
+            ) {
+                Text(s.cancel, fontSize = 16.ssp)
+            }
+            Button(
+                onClick = {
+                    val iRect = drawnRect
+                    if (iRect.width > 0 && iRect.height > 0) {
+                        val scaleX = imgW / iRect.width
+                        val scaleY = imgH / iRect.height
+                        val px = ((cropRect.left - iRect.left) * scaleX).roundToInt().coerceAtLeast(0)
+                        val py = ((cropRect.top - iRect.top) * scaleY).roundToInt().coerceAtLeast(0)
+                        val pw = (cropRect.width * scaleX).roundToInt().coerceAtMost(imgW.roundToInt() - px)
+                        val ph = (cropRect.height * scaleY).roundToInt().coerceAtMost(imgH.roundToInt() - py)
+                        val cropped = imageBytes.cropImage(px, py, pw, ph)
+                        onCropped(cropped)
+                    }
+                },
+                modifier = Modifier.weight(1f).height(50.sdp),
+                shape = RoundedCornerShape(12.sdp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF6075F2)
+                )
+            ) {
+                Text(s.save, fontSize = 16.ssp, fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ImageUtils.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ImageUtils.kt
@@ -3,3 +3,5 @@ package com.example.memegram
 import androidx.compose.ui.graphics.ImageBitmap
 
 expect fun ByteArray.decodeToImageBitmap(): ImageBitmap
+
+expect fun ByteArray.cropImage(x: Int, y: Int, width: Int, height: Int): ByteArray

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/LanguageScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/LanguageScreen.kt
@@ -19,6 +19,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.memegram.localization.LocalStrings
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
+import com.example.memegram.utils.ImageTopAppBarBox
 
 data class Language(
     val code: String,
@@ -67,6 +70,7 @@ fun LanguageScreen(
 
     Scaffold(
         topBar = {
+            ImageTopAppBarBox(topBarColor) { bgColor ->
             TopAppBar(
                 title = { Text(s.languageTitle) },
                 navigationIcon = {
@@ -79,11 +83,12 @@ fun LanguageScreen(
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = topBarColor,
+                    containerColor = bgColor,
                     titleContentColor = topBarTextColor,
                     navigationIconContentColor = topBarTextColor
                 )
             )
+            }
         }
     ) { paddingValues ->
         Column(
@@ -99,24 +104,24 @@ fun LanguageScreen(
                     Icon(Icons.Default.Search, contentDescription = null)
                 },
                 singleLine = true,
-                shape = RoundedCornerShape(12.dp),
+                shape = RoundedCornerShape(12.sdp),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp)
+                    .padding(horizontal = 16.sdp, vertical = 12.sdp)
             )
 
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .padding(bottom = 8.dp),
-                shape = RoundedCornerShape(12.dp),
-                tonalElevation = 2.dp
+                    .padding(horizontal = 16.sdp)
+                    .padding(bottom = 8.sdp),
+                shape = RoundedCornerShape(12.sdp),
+                tonalElevation = 2.sdp
             ) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                        .padding(horizontal = 16.sdp, vertical = 14.sdp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
@@ -124,12 +129,12 @@ fun LanguageScreen(
                         Text(
                             text = s.aiTranslation,
                             fontWeight = FontWeight.Medium,
-                            fontSize = 15.sp
+                            fontSize = 15.ssp
                         )
                         Text(
                             text = s.comingSoon,
                             color = Color.Gray,
-                            fontSize = 12.sp
+                            fontSize = 12.ssp
                         )
                     }
                     Switch(
@@ -143,14 +148,14 @@ fun LanguageScreen(
                 }
             }
 
-            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.sdp))
 
             LazyColumn(
                 contentPadding = PaddingValues(
-                    horizontal = 16.dp,
-                    vertical = 4.dp
+                    horizontal = 16.sdp,
+                    vertical = 4.sdp
                 ),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
+                verticalArrangement = Arrangement.spacedBy(4.sdp)
             ) {
                 items(filteredLanguages, key = { it.code }) { language ->
                     val isSelected = currentLang == language.code
@@ -160,8 +165,8 @@ fun LanguageScreen(
                             .clickable {
                                 viewModel.setLanguage(language.code)
                             },
-                        shape = RoundedCornerShape(10.dp),
-                        tonalElevation = if (isSelected) 4.dp else 1.dp,
+                        shape = RoundedCornerShape(10.sdp),
+                        tonalElevation = if (isSelected) 4.sdp else 1.sdp,
                         color = if (isSelected)
                             topBarColor.copy(alpha = 0.12f)
                         else
@@ -170,7 +175,7 @@ fun LanguageScreen(
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(horizontal = 16.dp, vertical = 14.dp),
+                                .padding(horizontal = 16.sdp, vertical = 14.sdp),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.SpaceBetween
                         ) {
@@ -178,12 +183,12 @@ fun LanguageScreen(
                                 Text(
                                     text = language.nameNative,
                                     fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-                                    fontSize = 15.sp,
+                                    fontSize = 15.ssp,
                                     color = if (isSelected) topBarColor else MaterialTheme.colorScheme.onSurface
                                 )
                                 Text(
                                     text = language.nameEnglish,
-                                    fontSize = 12.sp,
+                                    fontSize = 12.ssp,
                                     color = Color.Gray
                                 )
                             }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/LinkedDevicesScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/LinkedDevicesScreen.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.delay
 import androidx.compose.foundation.Image
 import io.github.alexzhirkevich.qrose.rememberQrCodePainter
 import com.example.memegram.localization.LocalStrings
+import com.example.memegram.utils.sdp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -89,18 +90,18 @@ fun LinkedDevicesScreen(
 
         LazyColumn(
             modifier = Modifier.fillMaxSize().padding(padding),
-            contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            contentPadding = PaddingValues(16.sdp),
+            verticalArrangement = Arrangement.spacedBy(12.sdp)
         ) {
             // ── Add device ────────────────────────────────────────────
             item {
                 Button(
                     onClick = { vm.initAddDevice() },
                     modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp)
+                    shape = RoundedCornerShape(12.sdp)
                 ) {
                     Icon(Icons.Default.QrCode, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
+                    Spacer(Modifier.width(8.sdp))
                     Text(s.addDeviceByQr)
                 }
             }
@@ -112,7 +113,7 @@ fun LinkedDevicesScreen(
                         s.pendingConfirmation,
                         style = MaterialTheme.typography.titleSmall,
                         color = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.padding(vertical = 4.dp)
+                        modifier = Modifier.padding(vertical = 4.sdp)
                     )
                 }
                 items(pending) { reg ->
@@ -132,7 +133,7 @@ fun LinkedDevicesScreen(
                     s.myDevices,
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(vertical = 4.dp)
+                    modifier = Modifier.padding(vertical = 4.sdp)
                 )
             }
             items(devices) { device ->
@@ -182,7 +183,7 @@ private fun DeviceCard(
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        shape    = RoundedCornerShape(12.dp),
+        shape    = RoundedCornerShape(12.sdp),
         colors   = CardDefaults.cardColors(
             containerColor = if (device.isCurrentDevice)
                 MaterialTheme.colorScheme.primaryContainer
@@ -190,7 +191,7 @@ private fun DeviceCard(
         )
     ) {
         Row(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(16.sdp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
@@ -200,14 +201,14 @@ private fun DeviceCard(
                 tint = if (device.isCurrentDevice)
                     MaterialTheme.colorScheme.primary
                 else MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(32.dp)
+                modifier = Modifier.size(32.sdp)
             )
-            Spacer(Modifier.width(12.dp))
+            Spacer(Modifier.width(12.sdp))
             Column(Modifier.weight(1f)) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(device.name, fontWeight = FontWeight.SemiBold)
                     if (device.isCurrentDevice) {
-                        Spacer(Modifier.width(6.dp))
+                        Spacer(Modifier.width(6.sdp))
                         Badge { Text(thisDeviceLabel) }
                     }
                 }
@@ -263,17 +264,17 @@ private fun PendingDeviceCard(
 ) {
     Card(
         modifier = Modifier.fillMaxWidth().border(
-            1.dp,
+            1.sdp,
             MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
-            RoundedCornerShape(12.dp)
+            RoundedCornerShape(12.sdp)
         ),
-        shape  = RoundedCornerShape(12.dp)
+        shape  = RoundedCornerShape(12.sdp)
     ) {
-        Column(Modifier.padding(16.dp)) {
+        Column(Modifier.padding(16.sdp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(Icons.Default.DeviceUnknown, contentDescription = null,
                     tint = MaterialTheme.colorScheme.primary)
-                Spacer(Modifier.width(8.dp))
+                Spacer(Modifier.width(8.sdp))
                 Column {
                     Text(registration.deviceName, fontWeight = FontWeight.Medium)
                     Text(
@@ -283,8 +284,8 @@ private fun PendingDeviceCard(
                     )
                 }
             }
-            Spacer(Modifier.height(12.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Spacer(Modifier.height(12.sdp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.sdp)) {
                 OutlinedButton(
                     onClick = onReject,
                     modifier = Modifier.weight(1f),
@@ -325,29 +326,29 @@ private fun QrDialog(
     }
 
     Dialog(onDismissRequest = onDismiss) {
-        Card(shape = RoundedCornerShape(16.dp)) {
+        Card(shape = RoundedCornerShape(16.sdp)) {
             Column(
                 modifier = Modifier
-                    .padding(24.dp)
+                    .padding(24.sdp)
                     .verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(addDeviceLabel, style = MaterialTheme.typography.titleMedium)
-                Spacer(Modifier.height(16.dp))
+                Spacer(Modifier.height(16.sdp))
 
                 Image(
                     painter = rememberQrCodePainter(payload),
                     contentDescription = addDeviceLabel,
                     modifier = Modifier
-                        .size(220.dp)
-                        .background(Color.White, RoundedCornerShape(8.dp))
-                        .border(2.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(8.dp))
-                        .padding(8.dp)
+                        .size(220.sdp)
+                        .background(Color.White, RoundedCornerShape(8.sdp))
+                        .border(2.sdp, MaterialTheme.colorScheme.outline, RoundedCornerShape(8.sdp))
+                        .padding(8.sdp)
                 )
 
-                Spacer(Modifier.height(20.dp))
+                Spacer(Modifier.height(20.sdp))
                 HorizontalDivider()
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(12.sdp))
 
                 Text(
                     copyCodeHint,
@@ -355,16 +356,16 @@ private fun QrDialog(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center
                 )
-                Spacer(Modifier.height(10.dp))
+                Spacer(Modifier.height(10.sdp))
 
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(
                             MaterialTheme.colorScheme.surfaceVariant,
-                            RoundedCornerShape(8.dp)
+                            RoundedCornerShape(8.sdp)
                         )
-                        .padding(start = 12.dp, end = 4.dp, top = 10.dp, bottom = 10.dp),
+                        .padding(start = 12.sdp, end = 4.sdp, top = 10.sdp, bottom = 10.sdp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
@@ -374,13 +375,13 @@ private fun QrDialog(
                         modifier = Modifier.weight(1f),
                         maxLines = 3
                     )
-                    Spacer(Modifier.width(4.dp))
+                    Spacer(Modifier.width(4.sdp))
                     IconButton(
                         onClick = {
                             clipboardManager.setText(AnnotatedString(shortCode))
                             codeCopied = true
                         },
-                        modifier = Modifier.size(40.dp)
+                        modifier = Modifier.size(40.sdp)
                     ) {
                         Icon(
                             imageVector = if (codeCopied) Icons.Default.Check
@@ -388,7 +389,7 @@ private fun QrDialog(
                             contentDescription = copyCodeLabel,
                             tint = if (codeCopied) MaterialTheme.colorScheme.primary
                             else MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.size(20.dp)
+                            modifier = Modifier.size(20.sdp)
                         )
                     }
                 }
@@ -398,11 +399,11 @@ private fun QrDialog(
                         codeCopiedLabel,
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.padding(top = 4.dp)
+                        modifier = Modifier.padding(top = 4.sdp)
                     )
                 }
 
-                Spacer(Modifier.height(16.dp))
+                Spacer(Modifier.height(16.sdp))
                 TextButton(onClick = onNavigateToScan) {
                     Text(scanQrInsteadLabel)
                 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/NotificationsScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/NotificationsScreen.kt
@@ -23,6 +23,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.memegram.localization.LocalStrings
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
+import com.example.memegram.utils.ImageTopAppBarBox
 
 sealed class NotifItem {
     data class Category(
@@ -129,7 +132,7 @@ fun NotificationsScreen(
                                     }
                                     muteDialogTarget = null
                                 }
-                                .padding(vertical = 12.dp),
+                                .padding(vertical = 12.sdp),
                             color = if (option == disableForever || option == disableForTime)
                                 MaterialTheme.colorScheme.error
                             else MaterialTheme.colorScheme.primary
@@ -195,7 +198,7 @@ fun NotificationsScreen(
                                     )
                                     showVibrateDialog = false
                                 }
-                                .padding(vertical = 10.dp),
+                                .padding(vertical = 10.sdp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             RadioButton(
@@ -207,7 +210,7 @@ fun NotificationsScreen(
                                     showVibrateDialog = false
                                 }
                             )
-                            Spacer(Modifier.width(8.dp))
+                            Spacer(Modifier.width(8.sdp))
                             Text(opt)
                         }
                     }
@@ -237,7 +240,7 @@ fun NotificationsScreen(
                                     )
                                     showRingtoneDialog = false
                                 }
-                                .padding(vertical = 10.dp),
+                                .padding(vertical = 10.sdp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             RadioButton(
@@ -249,7 +252,7 @@ fun NotificationsScreen(
                                     showRingtoneDialog = false
                                 }
                             )
-                            Spacer(Modifier.width(8.dp))
+                            Spacer(Modifier.width(8.sdp))
                             Text(opt)
                         }
                     }
@@ -264,6 +267,7 @@ fun NotificationsScreen(
 
     Scaffold(
         topBar = {
+            ImageTopAppBarBox(topBarColor) { bgColor ->
             TopAppBar(
                 title = { Text(s.notificationsTitle) },
                 navigationIcon = {
@@ -276,20 +280,21 @@ fun NotificationsScreen(
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = topBarColor,
+                    containerColor = bgColor,
                     titleContentColor = topBarTextColor,
                     navigationIconContentColor = topBarTextColor
                 )
             )
+            }
         }
     ) { paddingValues ->
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .padding(horizontal = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-            contentPadding = PaddingValues(vertical = 12.dp)
+                .padding(horizontal = 12.sdp),
+            verticalArrangement = Arrangement.spacedBy(4.sdp),
+            contentPadding = PaddingValues(vertical = 12.sdp)
         ) {
             items(displayData, key = { item ->
                 when (item) {
@@ -357,20 +362,20 @@ private fun CategoryItem(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick),
-        shape = RoundedCornerShape(12.dp),
-        tonalElevation = 2.dp
+        shape = RoundedCornerShape(12.sdp),
+        tonalElevation = 2.sdp
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 14.dp),
+                .padding(horizontal = 16.sdp, vertical = 14.sdp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(
                 text = category.name,
                 fontWeight = FontWeight.Bold,
-                fontSize = 16.sp
+                fontSize = 16.ssp
             )
             Icon(
                 imageVector = Icons.Default.KeyboardArrowDown,
@@ -396,33 +401,33 @@ private fun ChatNotifItem(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 12.dp)
+            .padding(start = 12.sdp)
             .clickable(onClick = onClick),
-        shape = RoundedCornerShape(10.dp),
-        tonalElevation = 1.dp
+        shape = RoundedCornerShape(10.sdp),
+        tonalElevation = 1.sdp
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(horizontal = 16.sdp, vertical = 12.sdp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(
                 modifier = Modifier
-                    .size(10.dp)
+                    .size(10.sdp)
                     .clip(CircleShape)
                     .background(indicatorColor)
             )
-            Spacer(Modifier.width(12.dp))
+            Spacer(Modifier.width(12.sdp))
             Text(
                 text = chat.name,
                 modifier = Modifier.weight(1f),
-                fontSize = 15.sp
+                fontSize = 15.ssp
             )
             Text(
                 text = statusText,
                 color = indicatorColor,
-                fontSize = 13.sp,
+                fontSize = 13.ssp,
                 fontWeight = FontWeight.Medium
             )
         }
@@ -440,17 +445,17 @@ private fun CallsSettingsBlock(
     onVibrateClick: () -> Unit,
     onRingtoneClick: () -> Unit
 ) {
-    Column(modifier = Modifier.padding(top = 20.dp)) {
+    Column(modifier = Modifier.padding(top = 20.sdp)) {
         Text(
             text = callsSectionLabel,
-            fontSize = 12.sp,
+            fontSize = 12.ssp,
             color = Color(0xFF8E8E93),
             fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(start = 4.dp, bottom = 6.dp)
+            modifier = Modifier.padding(start = 4.sdp, bottom = 6.sdp)
         )
         Surface(
-            shape = RoundedCornerShape(12.dp),
-            tonalElevation = 2.dp,
+            shape = RoundedCornerShape(12.sdp),
+            tonalElevation = 2.sdp,
             modifier = Modifier.fillMaxWidth()
         ) {
             Column {
@@ -458,33 +463,33 @@ private fun CallsSettingsBlock(
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable(onClick = onVibrateClick)
-                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                        .padding(horizontal = 16.sdp, vertical = 14.sdp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Text(vibrationLabel, fontSize = 15.sp)
+                    Text(vibrationLabel, fontSize = 15.ssp)
                     Text(
                         text = vibrate,
                         color = accentColor,
-                        fontSize = 15.sp
+                        fontSize = 15.ssp
                     )
                 }
 
-                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.sdp))
 
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable(onClick = onRingtoneClick)
-                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                        .padding(horizontal = 16.sdp, vertical = 14.sdp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Text(ringtoneLabel, fontSize = 15.sp)
+                    Text(ringtoneLabel, fontSize = 15.ssp)
                     Text(
                         text = ringtone,
                         color = accentColor,
-                        fontSize = 15.sp,
+                        fontSize = 15.ssp,
                         maxLines = 1
                     )
                 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/PrivacyScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/PrivacyScreen.kt
@@ -18,6 +18,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.memegram.localization.LocalStrings
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
+import com.example.memegram.utils.ImageTopAppBarBox
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -118,6 +121,7 @@ fun PrivacyScreen(
 
     Scaffold(
         topBar = {
+            ImageTopAppBarBox(topBarColor) { bgColor ->
             TopAppBar(
                 title = { Text(s.privacyTitle) },
                 navigationIcon = {
@@ -126,11 +130,12 @@ fun PrivacyScreen(
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = topBarColor,
+                    containerColor = bgColor,
                     titleContentColor = topBarTextColor,
                     navigationIconContentColor = topBarTextColor
                 )
             )
+            }
         }
     ) { paddingValues ->
         Column(
@@ -138,8 +143,8 @@ fun PrivacyScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
                 .verticalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+                .padding(horizontal = 16.sdp, vertical = 12.sdp),
+            verticalArrangement = Arrangement.spacedBy(8.sdp)
         ) {
             SectionLabel(s.contactsTitle)
             PrivacyItem(
@@ -149,7 +154,7 @@ fun PrivacyScreen(
                 onClick = onBlackListClick
             )
 
-            Spacer(Modifier.height(4.dp))
+            Spacer(Modifier.height(4.sdp))
 
             SectionLabel(s.privacySection)
             PrivacyItem(
@@ -165,7 +170,7 @@ fun PrivacyScreen(
                 onClick = { showLastActiveVisDialog = true }
             )
 
-            Spacer(Modifier.height(4.dp))
+            Spacer(Modifier.height(4.sdp))
 
             SectionLabel(s.autoDeleteSection)
             PrivacyItem(
@@ -181,29 +186,29 @@ fun PrivacyScreen(
                 onClick = { showAutoDeleteAccDialog = true }
             )
 
-            Spacer(Modifier.height(12.dp))
+            Spacer(Modifier.height(12.sdp))
 
             Surface(
                 modifier = Modifier.fillMaxWidth().clickable(enabled = !isLoading) {
                     showDeleteAccountDialog = true
                 },
-                shape = RoundedCornerShape(12.dp),
-                tonalElevation = 2.dp
+                shape = RoundedCornerShape(12.sdp),
+                tonalElevation = 2.sdp
             ) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 16.dp),
+                        .padding(horizontal = 16.sdp, vertical = 16.sdp),
                     contentAlignment = Alignment.CenterStart
                 ) {
                     if (isLoading) {
-                        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                        CircularProgressIndicator(modifier = Modifier.size(20.sdp), strokeWidth = 2.sdp)
                     } else {
                         Text(
                             s.deleteAccountAction,
                             color = MaterialTheme.colorScheme.error,
                             fontWeight = FontWeight.Medium,
-                            fontSize = 15.sp
+                            fontSize = 15.ssp
                         )
                     }
                 }
@@ -231,11 +236,11 @@ private fun PrivacyChoiceDialog(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable { onSelect(option) }
-                            .padding(vertical = 10.dp),
+                            .padding(vertical = 10.sdp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         RadioButton(selected = current == option, onClick = { onSelect(option) })
-                        Spacer(Modifier.width(8.dp))
+                        Spacer(Modifier.width(8.sdp))
                         Text(option)
                     }
                 }
@@ -249,8 +254,8 @@ private fun PrivacyChoiceDialog(
 @Composable
 private fun SectionLabel(text: String) {
     Text(
-        text, fontSize = 12.sp, color = Color(0xFF8E8E93), fontWeight = FontWeight.Bold,
-        modifier = Modifier.padding(start = 4.dp, bottom = 2.dp)
+        text, fontSize = 12.ssp, color = Color(0xFF8E8E93), fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(start = 4.sdp, bottom = 2.sdp)
     )
 }
 
@@ -264,19 +269,19 @@ private fun PrivacyItem(
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
-        shape = RoundedCornerShape(12.dp),
-        tonalElevation = 2.dp
+        shape = RoundedCornerShape(12.sdp),
+        tonalElevation = 2.sdp
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 14.dp),
+                .padding(horizontal = 16.sdp, vertical = 14.sdp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Column(Modifier.weight(1f)) {
-                Text(title, fontSize = 15.sp, fontWeight = FontWeight.Medium)
-                Text(subtitle, fontSize = 13.sp, color = accentColor)
+                Text(title, fontSize = 15.ssp, fontWeight = FontWeight.Medium)
+                Text(subtitle, fontSize = 13.ssp, color = accentColor)
             }
             if (showArrow) Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, null, tint = Color.Gray)
         }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ProfileScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ProfileScreen.kt
@@ -29,10 +29,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.memegram.localization.LocalStrings
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
+import com.example.memegram.utils.ImageTopAppBarBox
 import io.github.vinceglb.filekit.compose.rememberFilePickerLauncher
 import io.github.vinceglb.filekit.core.PickerMode
 import io.github.vinceglb.filekit.core.PickerType
 import kotlinx.coroutines.launch
+
+private enum class CropTarget { AVATAR, COVER }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -59,13 +64,24 @@ fun ProfileScreen(
     val clipboardManager = LocalClipboardManager.current
     var keyCopied by remember { mutableStateOf(false) }
 
+    var cropBytes by remember { mutableStateOf<ByteArray?>(null) }
+    var cropTarget by remember { mutableStateOf<CropTarget?>(null) }
+
     val avatarPicker = rememberFilePickerLauncher(
         type = PickerType.Image, mode = PickerMode.Single
-    ) { file -> file?.let { scope.launch { viewModel.updateAvatar(it.readBytes()) } } }
+    ) { file -> file?.let { scope.launch {
+        val bytes = it.readBytes()
+        cropBytes = bytes
+        cropTarget = CropTarget.AVATAR
+    } } }
 
     val coverPicker = rememberFilePickerLauncher(
         type = PickerType.Image, mode = PickerMode.Single
-    ) { file -> file?.let { scope.launch { viewModel.updateCover(it.readBytes()) } } }
+    ) { file -> file?.let { scope.launch {
+        val bytes = it.readBytes()
+        cropBytes = bytes
+        cropTarget = CropTarget.COVER
+    } } }
 
     error?.let { msg ->
         AlertDialog(
@@ -76,8 +92,34 @@ fun ProfileScreen(
         )
     }
 
+    // Show crop screen as full-screen overlay
+    if (cropBytes != null && cropTarget != null) {
+        val ratio = when (cropTarget!!) {
+            CropTarget.AVATAR -> 1f
+            CropTarget.COVER -> 2.5f
+        }
+        ImageCropScreen(
+            imageBytes = cropBytes!!,
+            aspectRatio = ratio,
+            onCropped = { croppedBytes ->
+                when (cropTarget!!) {
+                    CropTarget.AVATAR -> viewModel.updateAvatar(croppedBytes)
+                    CropTarget.COVER -> viewModel.updateCover(croppedBytes)
+                }
+                cropBytes = null
+                cropTarget = null
+            },
+            onCancel = {
+                cropBytes = null
+                cropTarget = null
+            }
+        )
+        return
+    }
+
     Scaffold(
         topBar = {
+            ImageTopAppBarBox(topBarColor) { bgColor ->
             TopAppBar(
                 title = { Text(s.profileTitle) },
                 navigationIcon = {
@@ -86,11 +128,12 @@ fun ProfileScreen(
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = topBarColor,
+                    containerColor = bgColor,
                     titleContentColor = topBarTextColor,
                     navigationIconContentColor = topBarTextColor
                 )
             )
+            }
         }
     ) { paddingValues ->
         Column(
@@ -103,7 +146,7 @@ fun ProfileScreen(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(150.dp)
+                    .aspectRatio(2.5f)
                     .clickable { coverPicker.launch() },
                 contentAlignment = Alignment.BottomEnd
             ) {
@@ -125,13 +168,13 @@ fun ProfileScreen(
                     ) {}
                 }
                 Surface(
-                    modifier = Modifier.padding(10.dp),
+                    modifier = Modifier.padding(10.sdp),
                     shape = CircleShape,
                     color = Color.Black.copy(alpha = 0.4f)
                 ) {
                     Icon(
                         Icons.Default.CameraAlt, null,
-                        modifier = Modifier.padding(7.dp).size(16.dp),
+                        modifier = Modifier.padding(7.sdp).size(16.sdp),
                         tint = Color.White
                     )
                 }
@@ -139,13 +182,13 @@ fun ProfileScreen(
 
             Box(
                 contentAlignment = Alignment.BottomEnd,
-                modifier = Modifier.offset(y = (-38).dp)
+                modifier = Modifier.offset(y = (-38).sdp)
             ) {
                 Box(
                     modifier = Modifier
-                        .size(80.dp)
+                        .size(80.sdp)
                         .clip(CircleShape)
-                        .border(3.dp, MaterialTheme.colorScheme.background, CircleShape)
+                        .border(3.sdp, MaterialTheme.colorScheme.background, CircleShape)
                         .clickable { avatarPicker.launch() },
                     contentAlignment = Alignment.Center
                 ) {
@@ -165,7 +208,7 @@ fun ProfileScreen(
                             Box(contentAlignment = Alignment.Center) {
                                 Text(
                                     username.take(1).uppercase(),
-                                    fontSize = 28.sp,
+                                    fontSize = 28.ssp,
                                     fontWeight = FontWeight.Bold,
                                     color = topBarTextColor
                                 )
@@ -176,7 +219,7 @@ fun ProfileScreen(
                 Surface(shape = CircleShape, color = Color.Black.copy(alpha = 0.45f)) {
                     Icon(
                         Icons.Default.CameraAlt, null,
-                        modifier = Modifier.padding(5.dp).size(13.dp),
+                        modifier = Modifier.padding(5.sdp).size(13.sdp),
                         tint = Color.White
                     )
                 }
@@ -185,9 +228,9 @@ fun ProfileScreen(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .offset(y = (-24).dp)
-                    .padding(horizontal = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
+                    .offset(y = (-24).sdp)
+                    .padding(horizontal = 16.sdp),
+                verticalArrangement = Arrangement.spacedBy(12.sdp)
             ) {
                 OutlinedTextField(
                     value = usernameInput,
@@ -195,7 +238,7 @@ fun ProfileScreen(
                     label = { Text(s.username) },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp),
+                    shape = RoundedCornerShape(12.sdp),
                     trailingIcon = {
                         if (usernameInput != username) {
                             TextButton(
@@ -212,8 +255,8 @@ fun ProfileScreen(
                     label = { Text(s.aboutMe) },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .heightIn(min = 90.dp),
-                    shape = RoundedCornerShape(12.dp),
+                        .heightIn(min = 90.sdp),
+                    shape = RoundedCornerShape(12.sdp),
                     maxLines = 5,
                     trailingIcon = {
                         if (bioInput != bio) {
@@ -232,30 +275,30 @@ fun ProfileScreen(
                             keyCopied = true
                         },
                         modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(12.dp)
+                        shape = RoundedCornerShape(12.sdp)
                     ) {
                         Icon(
                             if (keyCopied) Icons.Default.ContentCopy else Icons.Default.VpnKey,
                             contentDescription = null,
-                            modifier = Modifier.size(16.dp)
+                            modifier = Modifier.size(16.sdp)
                         )
-                        Spacer(Modifier.width(8.dp))
+                        Spacer(Modifier.width(8.sdp))
                         Text(if (keyCopied) s.copied else s.copyMyPublicKey)
                     }
                 }
 
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(16.sdp))
                 HorizontalDivider()
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(8.sdp))
 
                 Button(
                     onClick = { viewModel.logout(onLogoutDone) },
                     modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp),
+                    shape = RoundedCornerShape(12.sdp),
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
                 ) {
-                    Icon(Icons.Default.ExitToApp, contentDescription = null, modifier = Modifier.size(18.dp))
-                    Spacer(Modifier.width(8.dp))
+                    Icon(Icons.Default.ExitToApp, contentDescription = null, modifier = Modifier.size(18.sdp))
+                    Spacer(Modifier.width(8.sdp))
                     Text(s.logout)
                 }
 
@@ -263,9 +306,9 @@ fun ProfileScreen(
                     CircularProgressIndicator(
                         modifier = Modifier
                             .align(Alignment.CenterHorizontally)
-                            .size(26.dp)
-                            .padding(top = 16.dp),
-                        strokeWidth = 2.5.dp
+                            .size(26.sdp)
+                            .padding(top = 16.sdp),
+                        strokeWidth = 2.5f.sdp
                     )
                 }
             }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/StorageScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/StorageScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.example.memegram.localization.LocalStrings
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ImageTopAppBarBox
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -41,6 +43,7 @@ fun StorageScreen(
 
     Scaffold(
         topBar = {
+            ImageTopAppBarBox(topBarColor) { bgColor ->
             TopAppBar(
                 title = { Text(s.dataAndStorageTitle) },
                 navigationIcon = {
@@ -49,11 +52,12 @@ fun StorageScreen(
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = topBarColor,
+                    containerColor = bgColor,
                     titleContentColor = topBarTextColor,
                     navigationIconContentColor = topBarTextColor
                 )
             )
+            }
         }
     ) { paddingValues ->
         Column(
@@ -66,7 +70,7 @@ fun StorageScreen(
                 s.autoClearCache,
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(16.dp)
+                modifier = Modifier.padding(16.sdp)
             )
 
             val options = listOf(
@@ -122,32 +126,32 @@ fun StorageScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable { viewModel.setCleanupStrategy(key) }
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                        .padding(horizontal = 16.sdp, vertical = 12.sdp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     RadioButton(
                         selected = cleanupStrategy == key,
                         onClick = { viewModel.setCleanupStrategy(key) }
                     )
-                    Spacer(modifier = Modifier.width(12.dp))
+                    Spacer(modifier = Modifier.width(12.sdp))
                     Text(title, style = MaterialTheme.typography.bodyLarge)
                 }
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(24.sdp))
             HorizontalDivider()
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(24.sdp))
 
             OutlinedButton(
                 onClick = { viewModel.clearCache() },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                shape = RoundedCornerShape(12.dp),
+                    .padding(horizontal = 16.sdp),
+                shape = RoundedCornerShape(12.sdp),
                 colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error)
             ) {
-                Icon(Icons.Default.DeleteOutline, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(Modifier.width(8.dp))
+                Icon(Icons.Default.DeleteOutline, contentDescription = null, modifier = Modifier.size(18.sdp))
+                Spacer(Modifier.width(8.sdp))
                 Text(s.clearLocalCache)
             }
         }
@@ -169,12 +173,12 @@ fun StrategyParamSlider(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = 16.sdp, vertical = 8.sdp)
             .background(
                 MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-                RoundedCornerShape(12.dp)
+                RoundedCornerShape(12.sdp)
             )
-            .padding(12.dp)
+            .padding(12.sdp)
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -188,7 +192,7 @@ fun StrategyParamSlider(
                     inputText = raw
                     raw.toLongOrNull()?.coerceIn(min, max)?.let { onChanged(it) }
                 },
-                modifier = Modifier.width(96.dp),
+                modifier = Modifier.width(96.sdp),
                 singleLine = true,
                 textStyle = MaterialTheme.typography.bodyMedium,
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
@@ -206,7 +210,7 @@ fun StrategyParamSlider(
                 color = MaterialTheme.colorScheme.onSurfaceVariant)
             Text(description, style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.weight(1f).padding(horizontal = 8.dp),
+                modifier = Modifier.weight(1f).padding(horizontal = 8.sdp),
                 textAlign = TextAlign.Center)
             Text("$max", style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant)

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ThemePreferences.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ThemePreferences.kt
@@ -10,6 +10,8 @@ class ThemePreferences(private val settings: Settings) {
         val DefaultChatBg = Color(0xFFF5F5F5)
         val DefaultMyBubble = Color(0xFFD1C4E9)
         val DefaultTheirBubble = Color(0xFFFFFFFF)
+
+        private const val KEY_DARK_MODE = "app_dark_mode"
     }
 
     fun saveColor(key: String, color: Color) {
@@ -19,5 +21,13 @@ class ThemePreferences(private val settings: Settings) {
     fun getColor(key: String, defaultColor: Color): Color {
         val savedLong = settings.getLongOrNull(key) ?: return defaultColor
         return Color(savedLong.toULong())
+    }
+
+    fun isDarkMode(): Boolean {
+        return settings.getBoolean(KEY_DARK_MODE, false)
+    }
+
+    fun setDarkMode(enabled: Boolean) {
+        settings.putBoolean(KEY_DARK_MODE, enabled)
     }
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ThemeViewModel.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/ThemeViewModel.kt
@@ -1,16 +1,45 @@
 package com.example.memegram
 
 import androidx.lifecycle.ViewModel
+import com.russhwolf.settings.Settings
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 
+@OptIn(ExperimentalEncodingApi::class)
 class ThemeViewModel(
-    private val themePreferences: ThemePreferences
+    private val themePreferences: ThemePreferences,
+    private val settings: Settings
 ) : ViewModel() {
     private val _topBarColor = MutableStateFlow(themePreferences.getColor("topbar", ThemePreferences.DefaultTopBar))
     val topBarColor = _topBarColor.asStateFlow()
 
+    private val _topBarImage = MutableStateFlow<ByteArray?>(
+        settings.getStringOrNull("appearance_topbar_image")?.let {
+            runCatching { Base64.decode(it) }.getOrNull()
+        }
+    )
+    val topBarImage = _topBarImage.asStateFlow()
+
+    private val _isDarkMode = MutableStateFlow(themePreferences.isDarkMode())
+    val isDarkMode = _isDarkMode.asStateFlow()
+
     fun refreshTheme() {
         _topBarColor.value = themePreferences.getColor("topbar", ThemePreferences.DefaultTopBar)
+        _topBarImage.value = settings.getStringOrNull("appearance_topbar_image")?.let {
+            runCatching { Base64.decode(it) }.getOrNull()
+        }
+    }
+
+    fun toggleDarkMode() {
+        val newValue = !_isDarkMode.value
+        themePreferences.setDarkMode(newValue)
+        _isDarkMode.value = newValue
+    }
+
+    fun setDarkMode(enabled: Boolean) {
+        themePreferences.setDarkMode(enabled)
+        _isDarkMode.value = enabled
     }
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/UserProfileScreen.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/UserProfileScreen.kt
@@ -21,6 +21,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.memegram.localization.LocalStrings
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
+import com.example.memegram.utils.ImageTopAppBarBox
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -57,6 +60,7 @@ fun UserProfileScreen(
 
     Scaffold(
         topBar = {
+            ImageTopAppBarBox(topBarColor) { bgColor ->
             TopAppBar(
                 title = { Text(displayUsername, color = topBarTextColor) },
                 navigationIcon = {
@@ -64,8 +68,9 @@ fun UserProfileScreen(
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = topBarTextColor)
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = topBarColor)
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = bgColor)
             )
+            }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { paddingValues ->
@@ -78,7 +83,7 @@ fun UserProfileScreen(
             }
 
             Box(
-                modifier = Modifier.fillMaxWidth().height(150.dp),
+                modifier = Modifier.fillMaxWidth().aspectRatio(2.5f),
                 contentAlignment = Alignment.Center
             ) {
                 if (coverBytes != null) {
@@ -107,13 +112,13 @@ fun UserProfileScreen(
 
             Box(
                 contentAlignment = Alignment.Center,
-                modifier = Modifier.offset(y = (-40).dp)
+                modifier = Modifier.offset(y = (-40).sdp)
             ) {
                 Box(
                     modifier = Modifier
-                        .size(100.dp)
+                        .size(100.sdp)
                         .clip(CircleShape)
-                        .border(3.dp, MaterialTheme.colorScheme.background, CircleShape),
+                        .border(3.sdp, MaterialTheme.colorScheme.background, CircleShape),
                     contentAlignment = Alignment.Center
                 ) {
                     if (avatarBytes != null) {
@@ -129,14 +134,14 @@ fun UserProfileScreen(
                         } else {
                             Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.tertiary) {
                                 Box(contentAlignment = Alignment.Center) {
-                                    Text(displayUsername.take(1).uppercase(), color = Color.White, fontSize = 40.sp, fontWeight = FontWeight.Bold)
+                                    Text(displayUsername.take(1).uppercase(), color = Color.White, fontSize = 40.ssp, fontWeight = FontWeight.Bold)
                                 }
                             }
                         }
                     } else {
                         Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.tertiary) {
                             Box(contentAlignment = Alignment.Center) {
-                                Text(displayUsername.take(1).uppercase(), color = Color.White, fontSize = 40.sp, fontWeight = FontWeight.Bold)
+                                Text(displayUsername.take(1).uppercase(), color = Color.White, fontSize = 40.ssp, fontWeight = FontWeight.Bold)
                             }
                         }
                     }
@@ -147,41 +152,41 @@ fun UserProfileScreen(
                 displayUsername,
                 style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Bold,
-                modifier = Modifier.offset(y = (-24).dp)
+                modifier = Modifier.offset(y = (-24).sdp)
             )
 
             Text(
                 displayBio,
                 color = Color.Gray,
                 style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.offset(y = (-16).dp)
+                modifier = Modifier.offset(y = (-16).sdp)
             )
 
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(16.sdp))
 
             Row(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp),
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 32.sdp),
                 horizontalArrangement = Arrangement.SpaceEvenly
             ) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     FilledIconButton(
                         onClick = { profile?.userPublicKey?.let { onStartChat(it) } },
-                        modifier = Modifier.size(56.dp)
+                        modifier = Modifier.size(56.sdp)
                     ) {
                         Icon(Icons.AutoMirrored.Filled.Message, null)
                     }
-                    Spacer(Modifier.height(8.dp))
+                    Spacer(Modifier.height(8.sdp))
                     Text(s.sendMessage, style = MaterialTheme.typography.bodySmall)
                 }
 
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     FilledTonalIconButton(
                         onClick = { viewModel.addToContacts() },
-                        modifier = Modifier.size(56.dp)
+                        modifier = Modifier.size(56.sdp)
                     ) {
                         Icon(Icons.Default.PersonAdd, null)
                     }
-                    Spacer(Modifier.height(8.dp))
+                    Spacer(Modifier.height(8.sdp))
                     Text(s.addToContactsButton, style = MaterialTheme.typography.bodySmall)
                 }
             }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/audio/VoicePlaybackBar.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/audio/VoicePlaybackBar.kt
@@ -30,8 +30,8 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.example.memegram.utils.sdp
+import com.example.memegram.utils.ssp
 
 @Composable
 fun VoicePlaybackBar(
@@ -59,12 +59,12 @@ fun VoicePlaybackBar(
             modifier = modifier
                 .fillMaxWidth()
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                .padding(horizontal = 8.dp, vertical = 6.dp)
+                .padding(horizontal = 8.sdp, vertical = 6.sdp)
         ) {
             // ── play / pause ──
             Box(
                 modifier = Modifier
-                    .size(36.dp)
+                    .size(36.sdp)
                     .clip(CircleShape)
                     .background(accentColor.copy(alpha = 0.15f))
                     .clickable { onTogglePlayPause() },
@@ -74,16 +74,16 @@ fun VoicePlaybackBar(
                     imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
                     contentDescription = if (isPlaying) "Pause" else "Play",
                     tint = accentColor,
-                    modifier = Modifier.size(20.dp)
+                    modifier = Modifier.size(20.sdp)
                 )
             }
 
-            Spacer(Modifier.width(8.dp))
+            Spacer(Modifier.width(8.sdp))
 
             // ── waveform (scrubbable) ──
             val amplitudes = state.waveform.ifEmpty { List(30) { 1 } }
 
-            Box(modifier = Modifier.weight(1f).height(28.dp)) {
+            Box(modifier = Modifier.weight(1f).height(28.sdp)) {
                 ScrubbableWaveform(
                     amplitudes = amplitudes,
                     progress = state.progress,
@@ -94,7 +94,7 @@ fun VoicePlaybackBar(
                 )
             }
 
-            Spacer(Modifier.width(8.dp))
+            Spacer(Modifier.width(8.sdp))
 
             // ── time label ──
             val currentMs = (state.durationMs * state.progress).toLong()
@@ -102,16 +102,16 @@ fun VoicePlaybackBar(
             Text(
                 text = timeText,
                 color = textColor.copy(alpha = 0.7f),
-                fontSize = 11.sp,
+                fontSize = 11.ssp,
                 fontWeight = FontWeight.Medium
             )
 
-            Spacer(Modifier.width(8.dp))
+            Spacer(Modifier.width(8.sdp))
 
             // ── close button ──
             Box(
                 modifier = Modifier
-                    .size(28.dp)
+                    .size(28.sdp)
                     .clip(CircleShape)
                     .clickable { onClose() },
                 contentAlignment = Alignment.Center
@@ -120,7 +120,7 @@ fun VoicePlaybackBar(
                     imageVector = Icons.Default.Close,
                     contentDescription = "Close",
                     tint = textColor.copy(alpha = 0.6f),
-                    modifier = Modifier.size(18.dp)
+                    modifier = Modifier.size(18.sdp)
                 )
             }
         }
@@ -138,6 +138,9 @@ private fun ScrubbableWaveform(
     onSeek: (Float) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val barWidthDp = 3.sdp
+    val spacingDp = 2.sdp
+    val minBarHeightDp = 4.sdp
     Canvas(
         modifier = modifier
             .pointerInput(Unit) {
@@ -152,14 +155,14 @@ private fun ScrubbableWaveform(
                 }
             }
     ) {
-        val barWidth = 3.dp.toPx()
-        val spacing = 2.dp.toPx()
+        val barWidth = barWidthDp.toPx()
+        val spacing = spacingDp.toPx()
         val maxBars = (size.width / (barWidth + spacing)).toInt()
 
         val displayAmps = if (amplitudes.size > maxBars) amplitudes.takeLast(maxBars) else amplitudes
 
         displayAmps.forEachIndexed { index, amp ->
-            val barHeight = maxOf(4.dp.toPx(), (amp / 9f) * size.height)
+            val barHeight = maxOf(minBarHeightDp.toPx(), (amp / 9f) * size.height)
             val x = index * (barWidth + spacing)
             val isPlayed = (index.toFloat() / displayAmps.size) <= progress
 

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/data/models/ApiModels.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/data/models/ApiModels.kt
@@ -82,7 +82,10 @@ data class UserSettingsResponse(
     @SerialName("ringtone_media_id") val ringtoneMediaId: String? = null,
     @SerialName("ringtone_vibration_strength") val ringtoneVibrationStrength: Int? = null,
     @SerialName("notification_sound_media_id") val notificationSoundMediaId: String? = null,
-    @SerialName("notification_vibration_strength") val notificationVibrationStrength: Int? = null
+    @SerialName("notification_vibration_strength") val notificationVibrationStrength: Int? = null,
+    @SerialName("top_bar_media_id") val topBarMediaId: String? = null,
+    @SerialName("my_bubble_media_id") val myBubbleMediaId: String? = null,
+    @SerialName("their_bubble_media_id") val theirBubbleMediaId: String? = null
 )
 
 @Serializable
@@ -99,7 +102,10 @@ data class UpdateSettingsRequest(
     @SerialName("ringtone_media_id") val ringtoneMediaId: String? = null,
     @SerialName("notification_sound") val notificationSound: String? = null,
     @SerialName("notification_vibration_strength") val notificationVibrationStrength: Int? = null,
-    @SerialName("ringtone_vibration_strength") val ringtoneVibrationStrength: Int? = null
+    @SerialName("ringtone_vibration_strength") val ringtoneVibrationStrength: Int? = null,
+    @SerialName("top_bar_media_id") val topBarMediaId: String? = null,
+    @SerialName("my_bubble_media_id") val myBubbleMediaId: String? = null,
+    @SerialName("their_bubble_media_id") val theirBubbleMediaId: String? = null
 )
 
 @Serializable

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/data/repository/ChatRepository.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/data/repository/ChatRepository.kt
@@ -15,6 +15,7 @@ interface ChatRepository {
     suspend fun saveMessage(message: Message, conversationId: String)
     suspend fun saveMessages(messages: List<Message>, conversationId: String)
     suspend fun deleteMessages(conversationId: String)
+    suspend fun deleteMessageByServerId(serverId: String)
 
     suspend fun clearAllLocalData()
 

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/data/repository/ChatRepositoryImpl.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/data/repository/ChatRepositoryImpl.kt
@@ -132,7 +132,8 @@ class ChatRepositoryImpl(
                         encryptionMetadata = entity.encryptionMetadata,
                         localPreviewBytes  = entity.localPreviewBytes,
                         mediaUrl           = entity.mediaUrl,
-                        senderUserId       = entity.senderUserId
+                        senderUserId       = entity.senderUserId,
+                        groupId            = entity.groupId
                     )
 
                 }
@@ -153,13 +154,14 @@ class ChatRepositoryImpl(
                     realId, conversationId, message.text,
                     if (message.isOutgoing) 1L else 0L, message.timestamp, message.status.name,
                     message.type, message.mediaId, message.encryptionMetadata,
-                    message.localPreviewBytes, message.mediaUrl, now, message.senderUserId
+                    message.localPreviewBytes, message.mediaUrl, now, message.senderUserId,
+                    message.groupId
                 )
                 chatQueries.updateExistingMessage(
                     message.text, message.status.name,
                     message.type, message.mediaId, message.encryptionMetadata,
                     message.localPreviewBytes, message.mediaUrl, now, message.timestamp,
-                    message.senderUserId, realId
+                    message.senderUserId, message.groupId, realId
                 )
                 runGarbageCollector(conversationId)
             }
@@ -188,7 +190,8 @@ class ChatRepositoryImpl(
                         mediaUrl           = message.mediaUrl,
                         lastAccessedAt     = now,
                         accessCount        = 1L,
-                        senderUserId       = message.senderUserId
+                        senderUserId       = message.senderUserId,
+                        groupId            = message.groupId
                     )
 
                 }
@@ -200,6 +203,12 @@ class ChatRepositoryImpl(
     override suspend fun deleteMessages(conversationId: String) {
         withContext(ioDispatcher) {
             chatQueries.deleteMessagesByConversation(conversationId)
+        }
+    }
+
+    override suspend fun deleteMessageByServerId(serverId: String) {
+        withContext(ioDispatcher) {
+            chatQueries.deleteMessageByServerId(serverId)
         }
     }
 
@@ -231,7 +240,8 @@ class ChatRepositoryImpl(
                         encryptionMetadata = entity.encryptionMetadata,
                         localPreviewBytes  = entity.localPreviewBytes,
                         mediaUrl           = entity.mediaUrl,
-                        senderUserId       = entity.senderUserId
+                        senderUserId       = entity.senderUserId,
+                        groupId            = entity.groupId
                     )
                 }
         }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/localization/AppStrings.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/localization/AppStrings.kt
@@ -2,13 +2,6 @@ package com.example.memegram.localization
 
 import androidx.compose.runtime.staticCompositionLocalOf
 
-/**
- * All user-facing strings in the app.
- * Two implementations: [RuStrings] and [EnStrings].
- *
- * - In @Composable functions use `val s = LocalStrings.current`
- * - In ViewModels / plain Kotlin use `S.current`
- */
 interface AppStrings {
 
     // ── Common ────────────────────────────────────────────────────────
@@ -42,6 +35,7 @@ interface AppStrings {
     val settingsContacts: String
     val settingsLinkedDevices: String
     val settingsLanguage: String
+    val darkTheme: String
 
     // ── Chats list ───────────────────────────────────────────────────
     val searchPlaceholder: String
@@ -90,6 +84,7 @@ interface AppStrings {
     val messageDeleted: String
     val member: String
     val saveToGallery: String
+    fun saveAllNPhotos(count: Int): String
     val copyText: String
     val you: String
     val interlocutor: String
@@ -235,6 +230,14 @@ interface AppStrings {
     val myMessageColor: String
     val otherMessageColor: String
     val chooseColor: String
+    val colorPickerPresets: String
+    val colorPickerCustom: String
+    val colorPickerHex: String
+    val themeSection: String
+    val selectColor: String
+    val cropTitle: String
+    val setPhoto: String
+    val colorOrPhoto: String
 
     // ── Storage ──────────────────────────────────────────────────────
     val dataAndStorageTitle: String
@@ -348,6 +351,7 @@ object RuStrings : AppStrings {
     override val settingsContacts = "Контакты"
     override val settingsLinkedDevices = "Связанные устройства"
     override val settingsLanguage = "Язык"
+    override val darkTheme = "Тёмная тема"
 
     // Chats list
     override val searchPlaceholder = "Поиск..."
@@ -397,6 +401,7 @@ object RuStrings : AppStrings {
     override val messageDeleted = "Сообщение удалено"
     override val member = "Участник"
     override val saveToGallery = "Сохранить в галерею"
+    override fun saveAllNPhotos(count: Int) = "Сохранить все $count фото"
     override val copyText = "Копировать текст"
     override val you = "Вы"
     override val interlocutor = "Собеседник"
@@ -536,13 +541,21 @@ object RuStrings : AppStrings {
     override val appearanceTitle = "Внешний вид"
     override val preview = "Предпросмотр"
     override val chatPreview = "Чат"
-    override val previewMessage1 = "Привет! Как дела?"
-    override val previewMessage2 = "Всё супер, тестирую Compose!"
+    override val previewMessage1 = "Привет! Пойдём обедать сегодня?"
+    override val previewMessage2 = "Давай! Встречаемся в 12 \uD83D\uDE0A"
     override val topBarColor = "Цвет верхней панели"
     override val chatBgColor = "Цвет фона чата"
     override val myMessageColor = "Цвет моих сообщений"
     override val otherMessageColor = "Цвет чужих сообщений"
     override val chooseColor = "Выберите цвет"
+    override val colorPickerPresets = "Готовые"
+    override val colorPickerCustom = "Пользовательский"
+    override val colorPickerHex = "HEX"
+    override val themeSection = "Тема"
+    override val selectColor = "Выбрать"
+    override val cropTitle = "Обрезка фото"
+    override val setPhoto = "Фото"
+    override val colorOrPhoto = "Цвет / Фото"
 
     // Storage
     override val dataAndStorageTitle = "Данные и память"
@@ -657,6 +670,7 @@ object EnStrings : AppStrings {
     override val settingsContacts = "Contacts"
     override val settingsLinkedDevices = "Linked Devices"
     override val settingsLanguage = "Language"
+    override val darkTheme = "Dark theme"
 
     // Chats list
     override val searchPlaceholder = "Search..."
@@ -706,6 +720,7 @@ object EnStrings : AppStrings {
     override val messageDeleted = "Message deleted"
     override val member = "Member"
     override val saveToGallery = "Save to gallery"
+    override fun saveAllNPhotos(count: Int) = "Save all $count photos"
     override val copyText = "Copy text"
     override val you = "You"
     override val interlocutor = "Contact"
@@ -845,13 +860,21 @@ object EnStrings : AppStrings {
     override val appearanceTitle = "Appearance"
     override val preview = "Preview"
     override val chatPreview = "Chat"
-    override val previewMessage1 = "Hey! How are you?"
-    override val previewMessage2 = "Great, testing Compose!"
+    override val previewMessage1 = "Hey! Want to grab lunch today?"
+    override val previewMessage2 = "Sure! See you at noon \uD83D\uDE0A"
     override val topBarColor = "Top bar color"
     override val chatBgColor = "Chat background color"
     override val myMessageColor = "My message color"
     override val otherMessageColor = "Other message color"
     override val chooseColor = "Choose color"
+    override val colorPickerPresets = "Presets"
+    override val colorPickerCustom = "Custom"
+    override val colorPickerHex = "HEX"
+    override val themeSection = "Theme"
+    override val selectColor = "Select"
+    override val cropTitle = "Crop photo"
+    override val setPhoto = "Photo"
+    override val colorOrPhoto = "Color / Photo"
 
     // Storage
     override val dataAndStorageTitle = "Data and Storage"
@@ -930,14 +953,8 @@ object EnStrings : AppStrings {
     override val create = "Create"
 }
 
-// ═══════════════════════════════════════════════════════════════════════
-// Composition local for @Composable access
-// ═══════════════════════════════════════════════════════════════════════
 val LocalStrings = staticCompositionLocalOf<AppStrings> { EnStrings }
 
-// ═══════════════════════════════════════════════════════════════════════
-// Global singleton for ViewModel / non-composable access
-// ═══════════════════════════════════════════════════════════════════════
 object S {
     var current: AppStrings = EnStrings
 }

--- a/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/utils/Dimens.kt
+++ b/android-ios-app/composeApp/src/commonMain/kotlin/com/example/memegram/utils/Dimens.kt
@@ -1,0 +1,66 @@
+package com.example.memegram.utils
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+val LocalScreenWidthDp = compositionLocalOf { 360f }
+
+val LocalScreenHeightDp = compositionLocalOf { 640f }
+
+val LocalTopBarImage = staticCompositionLocalOf<ImageBitmap?> { null }
+
+private const val REFERENCE_WIDTH = 360f
+
+private const val MAX_SCALE_WIDTH = 450f
+
+@Composable
+fun screenScaleFactor(): Float {
+    val effectiveWidth = LocalScreenWidthDp.current.coerceAtMost(MAX_SCALE_WIDTH)
+    return effectiveWidth / REFERENCE_WIDTH
+}
+
+val Int.sdp: Dp
+    @Composable get() = (this * screenScaleFactor()).dp
+
+val Float.sdp: Dp
+    @Composable get() = (this * screenScaleFactor()).dp
+
+val Double.sdp: Dp
+    @Composable get() = (this.toFloat() * screenScaleFactor()).dp
+
+val Int.ssp: TextUnit
+    @Composable get() = (this * screenScaleFactor()).sp
+
+val Float.ssp: TextUnit
+    @Composable get() = (this * screenScaleFactor()).sp
+
+@Composable
+fun ImageTopAppBarBox(
+    fallbackColor: Color,
+    content: @Composable (containerColor: Color) -> Unit
+) {
+    val img = LocalTopBarImage.current
+    val effectiveColor = if (img != null) Color.Transparent else fallbackColor
+    Box {
+        if (img != null) {
+            Image(
+                bitmap = img,
+                contentDescription = null,
+                modifier = Modifier.matchParentSize(),
+                contentScale = ContentScale.Crop
+            )
+        }
+        content(effectiveColor)
+    }
+}

--- a/android-ios-app/composeApp/src/commonMain/sqldelight/com/example/memegram/database/AppDatabase.sq
+++ b/android-ios-app/composeApp/src/commonMain/sqldelight/com/example/memegram/database/AppDatabase.sq
@@ -24,7 +24,8 @@ CREATE TABLE messageEntity (
     mediaUrl             TEXT,
     lastAccessedAt       INTEGER NOT NULL DEFAULT 0,
     accessCount          INTEGER NOT NULL DEFAULT 0,
-    senderUserId         TEXT
+    senderUserId         TEXT,
+    groupId              TEXT
 );
 
 CREATE INDEX messageEntity_conversationId_idx ON messageEntity(conversationId);
@@ -46,9 +47,9 @@ insertMessage:
 INSERT OR REPLACE INTO messageEntity(
     serverId, conversationId, text, isOutgoing, timestamp, status,
     type, mediaId, encryptionMetadata, localPreviewBytes, mediaUrl,
-    lastAccessedAt, accessCount, senderUserId
+    lastAccessedAt, accessCount, senderUserId, groupId
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 deleteMessagesByConversation:
 DELETE FROM messageEntity WHERE conversationId = ?;
@@ -93,15 +94,15 @@ insertOrIgnoreMessage:
 INSERT OR IGNORE INTO messageEntity(
     serverId, conversationId, text, isOutgoing, timestamp, status,
     type, mediaId, encryptionMetadata, localPreviewBytes, mediaUrl,
-    lastAccessedAt, accessCount, senderUserId
+    lastAccessedAt, accessCount, senderUserId, groupId
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?);
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?);
 
 updateExistingMessage:
 UPDATE messageEntity
 SET text = ?, status = ?, type = ?, mediaId = ?,
     encryptionMetadata = ?, localPreviewBytes = ?, mediaUrl = ?,
-    lastAccessedAt = ?, timestamp = ?, senderUserId = ?
+    lastAccessedAt = ?, timestamp = ?, senderUserId = ?, groupId = ?
 WHERE serverId = ?;
 
 deleteMessageByServerId:

--- a/android-ios-app/composeApp/src/iosMain/kotlin/com/example/memegram/ImageUtils.ios.kt
+++ b/android-ios-app/composeApp/src/iosMain/kotlin/com/example/memegram/ImageUtils.ios.kt
@@ -2,7 +2,39 @@ package com.example.memegram
 
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toComposeImageBitmap
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorType
 import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
 
 actual fun ByteArray.decodeToImageBitmap(): ImageBitmap =
     Image.makeFromEncoded(this).toComposeImageBitmap()
+
+actual fun ByteArray.cropImage(x: Int, y: Int, width: Int, height: Int): ByteArray {
+    val image = Image.makeFromEncoded(this)
+    val bitmap = Bitmap.makeFromImage(image)
+    val cx = x.coerceIn(0, bitmap.width - 1)
+    val cy = y.coerceIn(0, bitmap.height - 1)
+    val cw = width.coerceAtMost(bitmap.width - cx)
+    val ch = height.coerceAtMost(bitmap.height - cy)
+
+    val croppedInfo = ImageInfo(cw, ch, ColorType.RGBA_8888, ColorAlphaType.PREMUL)
+    val croppedBitmap = Bitmap()
+    croppedBitmap.allocPixels(croppedInfo)
+
+    val srcRowBytes = bitmap.rowBytes
+    val srcPixels = bitmap.readPixels(bitmap.imageInfo, bitmap.rowBytes)!!
+    val dstPixels = ByteArray(cw * 4 * ch)
+
+    for (row in 0 until ch) {
+        val srcOffset = ((cy + row) * bitmap.width + cx) * 4
+        val dstOffset = row * cw * 4
+        srcPixels.copyInto(dstPixels, dstOffset, srcOffset, srcOffset + cw * 4)
+    }
+    croppedBitmap.installPixels(dstPixels)
+
+    val croppedImage = Image.makeFromBitmap(croppedBitmap)
+    val encoded = croppedImage.encodeToData() ?: error("Failed to encode cropped image")
+    return encoded.bytes
+}

--- a/backend/item-storage-service/app/services/item_storage_service.py
+++ b/backend/item-storage-service/app/services/item_storage_service.py
@@ -24,6 +24,21 @@ ITEM_TYPE_CONFIG: dict[str, dict] = {
         "max_size": 10 * 1024 * 1024,
         "access_policy": "owner_only",
     },
+    "top_bar": {
+        "allowed_mimes": {"image/jpeg", "image/png", "image/webp"},
+        "max_size": 5 * 1024 * 1024,
+        "access_policy": "owner_only",
+    },
+    "my_bubble": {
+        "allowed_mimes": {"image/jpeg", "image/png", "image/webp"},
+        "max_size": 5 * 1024 * 1024,
+        "access_policy": "owner_only",
+    },
+    "their_bubble": {
+        "allowed_mimes": {"image/jpeg", "image/png", "image/webp"},
+        "max_size": 5 * 1024 * 1024,
+        "access_policy": "owner_only",
+    },
     "notification_sound": {
         "allowed_mimes": {"audio/ogg", "audio/mpeg", "audio/aac"},
         "max_size": 1 * 1024 * 1024,

--- a/backend/orchestrator/app/api/v1/user/router.py
+++ b/backend/orchestrator/app/api/v1/user/router.py
@@ -108,6 +108,9 @@ _MEDIA_FIELDS = [
     ("chat_background_media_id", "chat_background"),
     ("ringtone_media_id", "ringtone"),
     ("notification_sound_media_id", "notification_sound"),
+    ("top_bar_media_id", "top_bar"),
+    ("my_bubble_media_id", "my_bubble"),
+    ("their_bubble_media_id", "their_bubble"),
 ]
 
 

--- a/backend/orchestrator/app/api/v1/user/schemas.py
+++ b/backend/orchestrator/app/api/v1/user/schemas.py
@@ -40,6 +40,9 @@ class UserSettingsResponseSchema(BaseModel):
     ringtone_vibration_strength: int
     notification_sound_media_id: Optional[str] = None
     notification_vibration_strength: int
+    top_bar_media_id: Optional[str] = None
+    my_bubble_media_id: Optional[str] = None
+    their_bubble_media_id: Optional[str] = None
 
 
 class UpdateUserSettingsRequestSchema(BaseModel):
@@ -56,6 +59,9 @@ class UpdateUserSettingsRequestSchema(BaseModel):
     ringtone_vibration_strength: Optional[int] = None
     notification_sound: Optional[str] = None
     notification_vibration_strength: Optional[int] = None
+    top_bar_media_id: Optional[str] = None
+    my_bubble_media_id: Optional[str] = None
+    their_bubble_media_id: Optional[str] = None
 
 
 # ── Settings sync (smart media caching) ──────────────────────────────
@@ -68,6 +74,9 @@ class SyncSettingsRequestSchema(BaseModel):
     chat_background_media_id: Optional[str] = None
     ringtone_media_id: Optional[str] = None
     notification_sound_media_id: Optional[str] = None
+    top_bar_media_id: Optional[str] = None
+    my_bubble_media_id: Optional[str] = None
+    their_bubble_media_id: Optional[str] = None
 
 
 class MediaDownloadInfoSchema(BaseModel):

--- a/backend/orchestrator/app/core/interfaces/user_gateway.py
+++ b/backend/orchestrator/app/core/interfaces/user_gateway.py
@@ -32,6 +32,9 @@ class UserSettingsResult:
     ringtone_vibration_strength: int = 1
     notification_sound_media_id: Optional[str] = None
     notification_vibration_strength: int = 1
+    top_bar_media_id: Optional[str] = None
+    my_bubble_media_id: Optional[str] = None
+    their_bubble_media_id: Optional[str] = None
 
 
 @dataclass
@@ -65,6 +68,9 @@ class UpdateUserSettingsRequest:
     ringtone_vibration_strength: Optional[int] = None
     notification_sound: Optional[str] = None
     notification_vibration_strength: Optional[int] = None
+    top_bar_media_id: Optional[str] = None
+    my_bubble_media_id: Optional[str] = None
+    their_bubble_media_id: Optional[str] = None
 
 
 @dataclass

--- a/backend/orchestrator/app/infrastructure/grpc/user_gateway.py
+++ b/backend/orchestrator/app/infrastructure/grpc/user_gateway.py
@@ -69,6 +69,9 @@ def _settings_from_response(s) -> UserSettingsResult:
         chat_background_media_id=_opt_media_id("chat_background_media_id"),
         ringtone_media_id=_opt_media_id("ringtone_media_id"),
         notification_sound_media_id=_opt_media_id("notification_sound"),
+        top_bar_media_id=_opt_media_id("top_bar_media_id"),
+        my_bubble_media_id=_opt_media_id("my_bubble_media_id"),
+        their_bubble_media_id=_opt_media_id("their_bubble_media_id"),
     )
 
 
@@ -168,6 +171,7 @@ class GrpcUserGateway(IUserGateway):
             "account_auto_delete_after_days", "profile_visible_to", "last_active_visible_to",
             "chat_background_media_id", "top_bar_color", "ringtone_media_id",
             "ringtone_vibration_strength", "notification_sound", "notification_vibration_strength",
+            "top_bar_media_id", "my_bubble_media_id", "their_bubble_media_id",
         ]
         for f in optional_fields:
             val = getattr(request, f, None)

--- a/backend/orchestrator/proto/user.proto
+++ b/backend/orchestrator/proto/user.proto
@@ -53,6 +53,9 @@ message UserSettings {
   int32  ringtone_vibration_strength   = 13;
   string notification_sound            = 14; // UUID, optional
   int32  notification_vibration_strength = 15;
+  string top_bar_media_id              = 16; // UUID, optional
+  string my_bubble_media_id            = 17; // UUID, optional
+  string their_bubble_media_id         = 18; // UUID, optional
 }
 
 
@@ -118,6 +121,9 @@ message UpdateUserSettingsRequest {
   optional int32  ringtone_vibration_strength     = 12;
   optional string notification_sound              = 13;
   optional int32  notification_vibration_strength = 14;
+  optional string top_bar_media_id                = 15;
+  optional string my_bubble_media_id              = 16;
+  optional string their_bubble_media_id           = 17;
 }
 
 message UserSettingsResponse {

--- a/backend/user-service/alembic/versions/a1b2c3d4e5f6_add_appearance_media_fields.py
+++ b/backend/user-service/alembic/versions/a1b2c3d4e5f6_add_appearance_media_fields.py
@@ -1,0 +1,30 @@
+"""add appearance media fields
+
+Revision ID: a1b2c3d4e5f6
+Revises: e0dcb814cbdf
+Create Date: 2026-04-12 18:15:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, Sequence[str], None] = 'e0dcb814cbdf'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('user_settings', sa.Column('top_bar_media_id', sa.UUID(), nullable=True))
+    op.add_column('user_settings', sa.Column('my_bubble_media_id', sa.UUID(), nullable=True))
+    op.add_column('user_settings', sa.Column('their_bubble_media_id', sa.UUID(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('user_settings', 'their_bubble_media_id')
+    op.drop_column('user_settings', 'my_bubble_media_id')
+    op.drop_column('user_settings', 'top_bar_media_id')

--- a/backend/user-service/app/grpc_handlers/user_handler.py
+++ b/backend/user-service/app/grpc_handlers/user_handler.py
@@ -52,6 +52,9 @@ def _settings_to_proto(s) -> user_pb2.UserSettings:
         ringtone_vibration_strength=s.ringtone_vibration_strength or 0,
         notification_sound=str(s.notification_sound) if s.notification_sound else "",
         notification_vibration_strength=s.notification_vibration_strength or 0,
+        top_bar_media_id=str(s.top_bar_media_id) if s.top_bar_media_id else "",
+        my_bubble_media_id=str(s.my_bubble_media_id) if s.my_bubble_media_id else "",
+        their_bubble_media_id=str(s.their_bubble_media_id) if s.their_bubble_media_id else "",
     )
 
 
@@ -269,6 +272,7 @@ class UserHandler(user_pb2_grpc.UserServiceServicer):
                     "last_active_visible_to", "chat_background_media_id", "top_bar_color",
                     "ringtone_media_id", "ringtone_vibration_strength",
                     "notification_sound", "notification_vibration_strength",
+                    "top_bar_media_id", "my_bubble_media_id", "their_bubble_media_id",
                 ]
                 kwargs = {
                     f: getattr(request, f)

--- a/backend/user-service/app/models/user_settings.py
+++ b/backend/user-service/app/models/user_settings.py
@@ -25,6 +25,9 @@ class UserSettings(Base):
 
     chat_background_media_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=True)
     top_bar_color: Mapped[str] = mapped_column(String(20), nullable=True)
+    top_bar_media_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=True)
+    my_bubble_media_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=True)
+    their_bubble_media_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=True)
 
     ringtone_media_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=True)
     ringtone_vibration_strength: Mapped[int] = mapped_column(Integer, default=1, nullable=False)

--- a/backend/user-service/app/services/user_service.py
+++ b/backend/user-service/app/services/user_service.py
@@ -197,8 +197,10 @@ class UserService:
             "account_auto_delete_after_days", "profile_visible_to", "last_active_visible_to",
             "chat_background_media_id", "top_bar_color", "ringtone_media_id",
             "ringtone_vibration_strength", "notification_sound", "notification_vibration_strength",
+            "top_bar_media_id", "my_bubble_media_id", "their_bubble_media_id",
         }
-        uuid_fields = {"chat_background_media_id", "ringtone_media_id", "notification_sound"}
+        uuid_fields = {"chat_background_media_id", "ringtone_media_id", "notification_sound",
+                       "top_bar_media_id", "my_bubble_media_id", "their_bubble_media_id"}
 
         for field, value in kwargs.items():
             if field in allowed_fields:

--- a/backend/user-service/proto/user.proto
+++ b/backend/user-service/proto/user.proto
@@ -53,6 +53,9 @@ message UserSettings {
   int32  ringtone_vibration_strength   = 13;
   string notification_sound            = 14; // UUID, optional
   int32  notification_vibration_strength = 15;
+  string top_bar_media_id              = 16; // UUID, optional
+  string my_bubble_media_id            = 17; // UUID, optional
+  string their_bubble_media_id         = 18; // UUID, optional
 }
 
 
@@ -118,6 +121,9 @@ message UpdateUserSettingsRequest {
   optional int32  ringtone_vibration_strength     = 12;
   optional string notification_sound              = 13;
   optional int32  notification_vibration_strength = 14;
+  optional string top_bar_media_id                = 15;
+  optional string my_bubble_media_id              = 16;
+  optional string their_bubble_media_id           = 17;
 }
 
 message UserSettingsResponse {


### PR DESCRIPTION
### Changes
- Added photo album grouping — multiple photos sent together are displayed as a Telegram-style adaptive grid (2 side-by-side, 3 = 2+1, 4 = 2x2, etc.) with shared caption and status indicators
- Album groupId is embedded in the E2E-encrypted MLS payload (`[image:mediaId:groupId]caption`), so the server never learns about grouping
- Context menu on albums includes "Save all N photos" option and bulk delete for the entire album
- Messages are now fully deleted from the local DB instead of being replaced with a "Message deleted" placeholder
- Added a complete appearance customization system — custom background images for chat background, top bar, my bubbles, and their bubbles (each can be a color or an uploaded photo)
- Added HSV color picker with two tabs: "Presets" (24 colors) and "Custom" (saturation/value panel + hue bar + hex input)
- Added image crop screen with drag-to-move, corner-resize handles, and configurable aspect ratios (1:1 for avatar, 2.5:1 for cover, screen ratio for top bar/chat bg, free for bubbles)
- Added dark mode support with toggle in Appearance settings and on the Auth screen
- Implemented scalable dimensions system (sdp/ssp) across all screens — reference width 360dp, scale factor capped at ~1.25x for larger screens
- Added pinch-to-zoom for the attachment gallery grid (2–6 columns)
- Chat scroll position is now saved per conversation and restored on re-entry; on first open, scrolls to the first unread message
- Auto-scroll on new messages only triggers when the user is near the bottom of the chat
- Added `launchSingleTop = true` to all navigation calls to prevent duplicate screens on double-tap
- CreateGroupScreen now passes both chatId and groupName so the chat opens with the correct name
- Cover image aspect ratio changed to 2.5:1 in ProfileScreen and UserProfileScreen
- Backend: added 3 new user settings fields (top_bar_media_id, my_bubble_media_id, their_bubble_media_id) with full pipeline — proto, gRPC, gateway, service, DB migration
- Backend: added 3 new item types in item-storage-service (top_bar, my_bubble, their_bubble) with 5MB limit and owner-only access
- Added new localization strings (EN + RU): dark theme, save all N photos, color picker labels, crop screen, theme section

### Bug fixes
- Fixed unread message count staying permanently for album messages — `chatItems` was a stale captured value inside `derivedStateOf`; converted to a proper derived state so read-tracking sees new messages
- Fixed message deletion not syncing to other users when a non-author deletes — added server-side reconciliation in both `loadMessages()` and `pollNewMessages()` that detects and removes locally-cached messages no longer present on the server
- Fixed album caption showing error text from failed photo uploads — caption now filters out FAILED status messages
- Fixed no visual feedback for failed photos in albums — added semi-transparent error overlay with ❌ on failed album cells